### PR TITLE
Mention explicit method registration in the spec

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -37,7 +37,7 @@ Inheritance lets us define a data taxonomy, and it is often natural to organize 
 
 ## Syntax
 
-Ideally the entire API could be free of side effects and odd conventions, like making the `.` character significant in method names. Direct manipulation of class and generic objects should enable this.
+The entire API should be free of side effects and odd conventions, like making the `.` character significant in method names. Whereas S3 supports implicit method registration based on the name of the method, the new system should require methods to be registered explicitly. Direct manipulation of class and generic objects should enable this.
 
 ## Namespaces
 


### PR DESCRIPTION
Implements @lawremi's suggestion from https://github.com/RConsortium/OOP-WG/issues/1#issuecomment-643441572. I feel this wraps up #1 if we want to keep the spec as general as it is now. (Not a strong opinion though, confirmation from others would be nice.)

Also cc @lionel-, I could not add you as a reviewer.