### PR TITLE
Guess signature from required arguments

### DIFF
--- a/R/generic.R
+++ b/R/generic.R
@@ -12,7 +12,7 @@ new_generic <- function(name, signature = NULL, fun = NULL) {
     stop("Must call `new_generic()` with either `signature` or `fun`", call. = FALSE)
   }
   if (is.null(signature)) {
-    signature <- formals(fun)[1]
+    signature <- guess_signature(fun)
   } else {
     signature <- normalize_signature(signature)
   }
@@ -40,6 +40,14 @@ new_external_generic <- function(package, generic, version = NULL) {
   class(out) <- "R7_external_generic"
   out
 }
+
+
+guess_signature <- function(fun) {
+  formals <- formals(fun)
+  is_required <- vlapply(formals, identical, quote(expr = ))
+  setdiff(names(formals[is_required]), "...")
+}
+
 
 normalize_signature <- function(signature, envir = parent.frame()) {
   if (!is_named(signature)) {

--- a/tests/testthat/test-generic.R
+++ b/tests/testthat/test-generic.R
@@ -23,3 +23,11 @@ test_that("generics pass ... to methods, and methods can define additional argum
   expect_equal(foo(text("bar")), "foo-bar")
   expect_equal(foo(text("bar"), sep = "/"), "foo/bar")
 })
+
+test_that("guesses signature from required arguments", {
+  expect_equal(guess_signature(function() {}), NULL)
+  expect_equal(guess_signature(function(x) {}), "x")
+  expect_equal(guess_signature(function(x, y) {}), c("x", "y"))
+  expect_equal(guess_signature(function(x, y, ...) {}), c("x", "y"))
+  expect_equal(guess_signature(function(x, ..., y = 1) {}), "x")
+})


### PR DESCRIPTION
We could probably make this more sophisticated (maybe all optional arguments before `...`, or before the first required argument), but folks can always supply their own signature if they want something more complicated, and I think this is a meaningful (if mild) improvement over just using the first argument.