### PR TITLE
Allow R7_class to be printed

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -81,9 +81,8 @@ print.R7_class <- function(x, ...) {
   } else {
     prop_fmt <- ""
   }
-  parent <- x@parent
-
-  parent <- property_safely(parent, "name") %||% parent
+  parent <- property_safely(x, "parent")
+  parent <- property_safely(parent, "name") %||% parent %||% ""
 
   cat(sprintf("<R7_class>\n@name %s\n@parent <%s>\n@properties\n%s", x@name, parent, prop_fmt), sep = "")
 }

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -1,3 +1,13 @@
+# R7_class: can be printed
+
+    Code
+      my_class
+    Output
+      <R7_class>
+      @name my_class
+      @parent <R7_object>
+      @properties
+
 # classes can use unions in properties
 
     <my_class>@name must be of class <character>, <factor>:

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -21,6 +21,9 @@ describe("R7_class", {
   it("has a list of properties", {
     expect_type(my_class@properties, "list")
   })
+  it("can be printed", {
+    expect_snapshot(my_class)
+  })
 })
 
 test_that("classes can inherit from base types", {


### PR DESCRIPTION
Even though it doesn't have a parent