### PR TITLE
Fully define constructor

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -91,52 +91,6 @@ new_class <- function(name, parent = R7_object, constructor = NULL, validator = 
   R7_class(name = name, parent = parent, constructor = constructor, validator = validator, properties = properties)
 }
 
-new_constructor <- function(parent, properties) {
-  args <- constructor_args(parent, properties)
-
-  self_args <- as_names(args$self, named = TRUE)
-
-  if (identical(parent, R7_object)) {
-    parent_call <- NULL
-    env <- asNamespace("R7")
-  } else {
-    parent_name <- parent@name
-    parent_args <- as_names(args$parent, named = TRUE)
-    parent_call <- as.call(c(list(as.name(parent_name)), parent_args))
-
-    env <- new.env(parent = asNamespace("R7"))
-    env[[parent_name]] <- parent
-  }
-  call <- as.call(c(list(quote(new_object), parent_call), self_args))
-
-  f <- function() {}
-  formals(f) <- lapply(setNames(, args$constructor), function(i) quote(expr = ))
-  body(f) <- call
-  environment(f) <- env
-  attr(f, "srcref") <- NULL
-
-  f
-}
-
-constructor_args <- function(parent, properties = list()) {
-  parent_args <- names2(formals(parent))
-
-  self_args <- names2(properties)
-  # Remove dynamic arguments
-  self_args <- self_args[vlapply(properties, function(x) is.null(x$getter))]
-  # Remove any parent properties; can't use parent_args() since the constructor
-  # might automatically set some properties.
-  self_args <- setdiff(self_args, names2(parent@properties))
-
-  constructor_args <- union(parent_args, self_args)
-
-  list(
-    parent = parent_args,
-    self = self_args,
-    constructor = constructor_args
-  )
-}
-
 #' Retrieve all of the class names for a class
 #'
 #' @param object The R7 object to query

--- a/R/class.R
+++ b/R/class.R
@@ -92,38 +92,49 @@ new_class <- function(name, parent = R7_object, constructor = NULL, validator = 
 }
 
 new_constructor <- function(parent, properties) {
-  parent_name <- parent@name
-  parent_props <- setNames(nm = names(formals(parent)))
+  args <- constructor_args(parent, properties)
 
-  self_props <- names(properties)
-  self_props <- self_props[vlapply(properties, function(x) is.null(x$getter))]
-  self_props <- setdiff(self_props, names(parent@properties))
-  self_props <- setNames(nm = self_props)
-
-  constructor_args <- setNames(nm = union(parent_props, self_props))
+  self_args <- as_names(args$self, named = TRUE)
 
   if (identical(parent, R7_object)) {
-    args <- lapply(self_props, as.name)
-    call <- as.call(c(list(quote(new_object), .data = NULL), args))
+    parent_call <- NULL
     env <- asNamespace("R7")
   } else {
-    env <- new.env(parent = asNamespace("R7"))
-    env[[parent_name]] <- parent
-    parent_args <- lapply(parent_props, as.name)
+    parent_name <- parent@name
+    parent_args <- as_names(args$parent, named = TRUE)
     parent_call <- as.call(c(list(as.name(parent_name)), parent_args))
 
-    new_props <- setNames(nm = self_props)
-    args <- lapply(new_props, as.name)
-    call <- as.call(c(list(quote(new_object), parent_call), args))
+    env <- new.env(parent = asNamespace("R7"))
+    env[[parent_name]] <- parent
   }
+  call <- as.call(c(list(quote(new_object), parent_call), self_args))
 
   f <- function() {}
-  formals(f) <- lapply(constructor_args, function(i) quote(expr = ))
+  formals(f) <- lapply(setNames(, args$constructor), function(i) quote(expr = ))
   body(f) <- call
   environment(f) <- env
   attr(f, "srcref") <- NULL
 
   f
+}
+
+constructor_args <- function(parent, properties = list()) {
+  parent_args <- names2(formals(parent))
+
+  self_args <- names2(properties)
+  # Remove dynamic arguments
+  self_args <- self_args[vlapply(properties, function(x) is.null(x$getter))]
+  # Remove any parent properties; can't use parent_args() since the constructor
+  # might automatically set some properties.
+  self_args <- setdiff(self_args, names2(parent@properties))
+
+  constructor_args <- union(parent_args, self_args)
+
+  list(
+    parent = parent_args,
+    self = self_args,
+    constructor = constructor_args
+  )
 }
 
 #' Retrieve all of the class names for a class

--- a/R/class.R
+++ b/R/class.R
@@ -95,8 +95,12 @@ new_constructor <- function(parent, properties) {
   parent_name <- parent@name
   parent_props <- setNames(nm = names(formals(parent)))
 
-  no_getter <- vlapply(properties, function(x) is.null(x$getter))
-  self_props <- setNames(nm = union(parent_props, names(properties)[no_getter]))
+  self_props <- names(properties)
+  self_props <- self_props[vlapply(properties, function(x) is.null(x$getter))]
+  self_props <- setdiff(self_props, names(parent@properties))
+  self_props <- setNames(nm = self_props)
+
+  constructor_args <- setNames(nm = union(parent_props, self_props))
 
   if (identical(parent, R7_object)) {
     args <- lapply(self_props, as.name)
@@ -108,13 +112,13 @@ new_constructor <- function(parent, properties) {
     parent_args <- lapply(parent_props, as.name)
     parent_call <- as.call(c(list(as.name(parent_name)), parent_args))
 
-    new_props <- setNames(nm = setdiff(self_props, parent_props))
+    new_props <- setNames(nm = self_props)
     args <- lapply(new_props, as.name)
     call <- as.call(c(list(quote(new_object), parent_call), args))
   }
 
   f <- function() {}
-  formals(f) <- lapply(self_props, function(i) quote(expr = ))
+  formals(f) <- lapply(constructor_args, function(i) quote(expr = ))
   body(f) <- call
   environment(f) <- env
   attr(f, "srcref") <- NULL

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -1,0 +1,45 @@
+new_constructor <- function(parent, properties) {
+  args <- constructor_args(parent, properties)
+
+  self_args <- as_names(args$self, named = TRUE)
+
+  if (identical(parent, R7_object)) {
+    parent_call <- NULL
+    env <- asNamespace("R7")
+  } else {
+    parent_name <- parent@name
+    parent_args <- as_names(args$parent, named = TRUE)
+    parent_call <- as.call(c(list(as.name(parent_name)), parent_args))
+
+    env <- new.env(parent = asNamespace("R7"))
+    env[[parent_name]] <- parent
+  }
+  call <- as.call(c(list(quote(new_object), parent_call), self_args))
+
+  f <- function() {}
+  formals(f) <- lapply(setNames(, args$constructor), function(i) quote(expr = ))
+  body(f) <- call
+  environment(f) <- env
+  attr(f, "srcref") <- NULL
+
+  f
+}
+
+constructor_args <- function(parent, properties = list()) {
+  parent_args <- names2(formals(parent))
+
+  self_args <- names2(properties)
+  # Remove dynamic arguments
+  self_args <- self_args[vlapply(properties, function(x) is.null(x$getter))]
+  # Remove any parent properties; can't use parent_args() since the constructor
+  # might automatically set some properties.
+  self_args <- setdiff(self_args, names2(parent@properties))
+
+  constructor_args <- union(parent_args, self_args)
+
+  list(
+    parent = parent_args,
+    self = self_args,
+    constructor = constructor_args
+  )
+}

--- a/R/property.R
+++ b/R/property.R
@@ -85,7 +85,7 @@ new_property <- function(name, class = NULL, getter = NULL, setter = NULL) {
 #'   colour = "character",
 #'   height = "numeric"
 #' ))
-#' lexington <- horse(colour = "bay", height = 15)
+#' lexington <- horse(colour = "bay", height = 15, name = "Lex")
 #' lexington@colour
 #' prop(lexington, "colour")
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,3 +50,19 @@ method_signature <- function(signature) {
   }
   collapse(vcapply(signature, format_signature), by = ", ")
 }
+
+as_names <- function(x, named = FALSE) {
+  if (named) {
+    names(x) <- x
+  }
+  lapply(x, as.name)
+}
+
+names2 <- function(x) {
+  nms <- names(x)
+  if (is.null(nms)) {
+    rep("", length(x))
+  } else {
+    nms
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,18 +15,18 @@ new_base_class <- function(name) {
 }
 
 base_classes <- new.env(parent = emptyenv())
-base_classes[["logical"]]    <- new_base_class("logical")
-base_classes[["integer"]]    <- new_base_class("integer")
-base_classes[["double"]]     <- new_base_class("double")
-base_classes[["numeric"]]    <- new_base_class("numeric")
-base_classes[["complex"]]    <- new_base_class("complex")
-base_classes[["character"]]  <- new_base_class("character")
-base_classes[["factor"]]     <- new_base_class("factor")
-base_classes[["raw"]]        <- new_base_class("raw")
-base_classes[["function"]]   <- new_base_class("function")
-base_classes[["list"]]       <- new_base_class("list")
+base_classes[["logical"]] <- new_base_class("logical")
+base_classes[["integer"]] <- new_base_class("integer")
+base_classes[["double"]] <- new_base_class("double")
+base_classes[["numeric"]] <- new_base_class("numeric")
+base_classes[["complex"]] <- new_base_class("complex")
+base_classes[["character"]] <- new_base_class("character")
+base_classes[["factor"]] <- new_base_class("factor")
+base_classes[["raw"]] <- new_base_class("raw")
+base_classes[["function"]] <- new_base_class("function")
+base_classes[["list"]] <- new_base_class("list")
 base_classes[["data.frame"]] <- new_base_class("data.frame")
-base_classes[["NULL"]]       <- new_base_class("NULL")
+base_classes[["NULL"]] <- new_base_class("NULL")
 
 #' R7 generics and method objects
 #' @param name,generic The name or generic object of the generic

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,19 +10,23 @@ R7_object <- new_class(
   }
 )
 
+new_base_class <- function(name) {
+  R7_class(name = name, constructor = function(.data) new_object(.data))
+}
+
 base_classes <- new.env(parent = emptyenv())
-base_classes[["logical"]] <- new_class("logical", constructor = function(x = logical()) new_object(x))
-base_classes[["integer"]] <- new_class("integer", constructor = function(x = integer()) new_object(x))
-base_classes[["double"]] <- new_class("double", constructor = function(x = double()) new_object(x))
-base_classes[["numeric"]] <- new_class("numeric", constructor = function(x = numeric()) new_object(x))
-base_classes[["complex"]] <- new_class("complex", constructor = function(x = complex()) new_object(x))
-base_classes[["character"]] <- new_class("character", constructor = function(x = character()) new_object(x))
-base_classes[["factor"]] <- new_class("factor", constructor = function(x = factor()) new_object(x))
-base_classes[["raw"]] <- new_class("raw", constructor = function(x = raw()) new_object(x))
-base_classes[["function"]] <- new_class("function", constructor = function(x = function() NULL) new_object(x))
-base_classes[["list"]] <- new_class("list", constructor = function(x = list()) new_object(x))
-base_classes[["data.frame"]] <- new_class("data.frame", constructor = function(x = data.frame()) new_object(x))
-base_classes[["NULL"]] <- new_class("NULL", constructor = function(x = NULL) new_object(x))
+base_classes[["logical"]]    <- new_base_class("logical")
+base_classes[["integer"]]    <- new_base_class("integer")
+base_classes[["double"]]     <- new_base_class("double")
+base_classes[["numeric"]]    <- new_base_class("numeric")
+base_classes[["complex"]]    <- new_base_class("complex")
+base_classes[["character"]]  <- new_base_class("character")
+base_classes[["factor"]]     <- new_base_class("factor")
+base_classes[["raw"]]        <- new_base_class("raw")
+base_classes[["function"]]   <- new_base_class("function")
+base_classes[["list"]]       <- new_base_class("list")
+base_classes[["data.frame"]] <- new_base_class("data.frame")
+base_classes[["NULL"]]       <- new_base_class("NULL")
 
 #' R7 generics and method objects
 #' @param name,generic The name or generic object of the generic

--- a/man/prop.Rd
+++ b/man/prop.Rd
@@ -54,7 +54,7 @@ horse <- new_class("horse", properties = list(
   colour = "character",
   height = "numeric"
 ))
-lexington <- horse(colour = "bay", height = 15)
+lexington <- horse(colour = "bay", height = 15, name = "Lex")
 lexington@colour
 prop(lexington, "colour")
 

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -13,27 +13,3 @@
     <my_class>@name must be of class <character>, <factor>:
     - `value` is of class <numeric>
 
-# generates meaningful constructors
-
-    Code
-      foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"))
-      foo@constructor
-    Output
-      function (x, y) 
-      new_object(NULL, x = x, y = y)
-      <environment: namespace:R7>
-    Code
-      foo <- new_class("foo", parent = "character")
-      foo@constructor
-    Output
-      function (.data) 
-      new_object(character(.data = .data))
-      <environment: 0x0>
-    Code
-      foo2 <- new_class("foo2", parent = foo)
-      foo2@constructor
-    Output
-      function (.data) 
-      new_object(foo(.data = .data))
-      <environment: 0x0>
-

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -13,3 +13,43 @@
     <my_class>@name must be of class <character>, <factor>:
     - `value` is of class <numeric>
 
+# generates meaningful constructors
+
+    Code
+      foo <- new_class("foo")
+      foo@constructor
+    Output
+      function () 
+      new_object(.data = NULL)
+      <environment: namespace:R7>
+    Code
+      foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"))
+      foo@constructor
+    Output
+      function (x, y) 
+      new_object(.data = NULL, x = x, y = y)
+      <environment: namespace:R7>
+    Code
+      foo <- new_class("foo", parent = "character")
+      foo@constructor
+    Output
+      function (.data) 
+      new_object(character(.data = .data))
+      <environment: 0x0>
+    Code
+      foo2 <- new_class("foo2", parent = foo)
+      foo2@constructor
+    Output
+      function (.data) 
+      new_object(foo(.data = .data))
+      <environment: 0x0>
+    Code
+      foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"),
+      constructor = function() new_object(x = 1, y = 2))
+      foo2 <- new_class("foo2", parent = foo, properties = list(z = "numeric"))
+      foo2@constructor
+    Output
+      function (z) 
+      new_object(foo(), z = z)
+      <environment: 0x0>
+

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -16,18 +16,11 @@
 # generates meaningful constructors
 
     Code
-      foo <- new_class("foo")
-      foo@constructor
-    Output
-      function () 
-      new_object(.data = NULL)
-      <environment: namespace:R7>
-    Code
       foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"))
       foo@constructor
     Output
       function (x, y) 
-      new_object(.data = NULL, x = x, y = y)
+      new_object(NULL, x = x, y = y)
       <environment: namespace:R7>
     Code
       foo <- new_class("foo", parent = "character")
@@ -42,14 +35,5 @@
     Output
       function (.data) 
       new_object(foo(.data = .data))
-      <environment: 0x0>
-    Code
-      foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"),
-      constructor = function() new_object(x = 1, y = 2))
-      foo2 <- new_class("foo2", parent = foo, properties = list(z = "numeric"))
-      foo2@constructor
-    Output
-      function (z) 
-      new_object(foo(), z = z)
       <environment: 0x0>
 

--- a/tests/testthat/_snaps/constructor.md
+++ b/tests/testthat/_snaps/constructor.md
@@ -1,0 +1,29 @@
+# generates meaningful constructors
+
+    Code
+      new_constructor(R7_object, list())
+    Output
+      function () 
+      new_object(NULL)
+      <environment: namespace:R7>
+    Code
+      new_constructor(R7_object, as_properties(list(x = "numeric", y = "numeric")))
+    Output
+      function (x, y) 
+      new_object(NULL, x = x, y = y)
+      <environment: namespace:R7>
+    Code
+      foo <- new_class("foo", parent = "character")
+      new_constructor(foo, list())
+    Output
+      function (.data) 
+      new_object(foo(.data = .data))
+      <environment: 0x0>
+    Code
+      foo2 <- new_class("foo2", parent = foo)
+      new_constructor(foo2, list())
+    Output
+      function (.data) 
+      new_object(foo2(.data = .data))
+      <environment: 0x0>
+

--- a/tests/testthat/_snaps/object.md
+++ b/tests/testthat/_snaps/object.md
@@ -4,19 +4,19 @@
       foo <- new_class("foo")
       foo(1)
     Error <simpleError>
-      All arguments to <foo> constructor must be named
+      unused argument (1)
     Code
       foo(1, 2)
     Error <simpleError>
-      All arguments to <foo> constructor must be named
+      unused arguments (1, 2)
     Code
       foo(x = 1)
     Error <simpleError>
-      All arguments to <foo> constructor must be properties: x
+      unused argument (x = 1)
     Code
       foo(x = 1, y = 2)
     Error <simpleError>
-      All arguments to <foo> constructor must be properties: x, y
+      unused arguments (x = 1, y = 2)
 
 # printing R7 objects work
 

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -53,11 +53,44 @@ test_that("classes can use unions in properties", {
   expect_snapshot_error(my_class(name = 1))
 })
 
+
+# constructor -------------------------------------------------------------
+
+test_that("generates correct arguments from parent + properties",  {
+  # No arguments
+  args <- constructor_args(R7_object)
+  expect_equal(args$constructor, character())
+
+  # Includes properties
+  args <- constructor_args(R7_object, as_properties(list(x = "numeric")))
+  expect_equal(args$constructor, "x")
+
+  # unless they're dynamic
+  args <- constructor_args(R7_object,
+    as_properties(list(new_property("x", getter = function(x) 10)))
+  )
+  expect_equal(args$constructor, character())
+
+  # Includes parent properties
+  foo <- new_class("foo", properties = list(x = "numeric"))
+  args <- constructor_args(foo, as_properties(list(y = "numeric")))
+  expect_equal(args$constructor, c("x", "y"))
+  expect_equal(args$self, "y")
+  expect_equal(args$parent, "x")
+
+  # But only those in the constructor
+  foo <- new_class("foo",
+    properties = list(x = "numeric"),
+    constructor = function() new_object(x = 1)
+  )
+  args <- constructor_args(foo, as_properties(list(y = "numeric")))
+  expect_equal(args$constructor, "y")
+  expect_equal(args$self, "y")
+  expect_equal(args$parent, character())
+})
+
 test_that("generates meaningful constructors", {
   expect_snapshot({
-    foo <- new_class("foo")
-    foo@constructor
-
     foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"))
     foo@constructor
 
@@ -65,13 +98,6 @@ test_that("generates meaningful constructors", {
     foo@constructor
 
     foo2 <- new_class("foo2", parent = foo)
-    foo2@constructor
-
-    foo <- new_class("foo",
-      properties = list(x = "numeric", y = "numeric"),
-      constructor = function() new_object(x = 1, y = 2)
-    )
-    foo2 <- new_class("foo2", parent = foo, properties = list(z = "numeric"))
     foo2@constructor
   }, transform = scrub_environment)
 })

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -53,51 +53,16 @@ test_that("classes can use unions in properties", {
   expect_snapshot_error(my_class(name = 1))
 })
 
+test_that("default constructor works", {
+  foo1 <- new_class("foo1", properties = list(x = "numeric"))
+  foo2 <- new_class("foo2", parent = foo1, properties = list(y = "numeric"))
+  expect_s3_class(foo1(x = 1), "foo1")
+  expect_s3_class(foo2(x = 1, y = 2), "foo2")
+
+  text1 <- new_class("text1", parent = "character")
+  text2 <- new_class("text2", parent = text1, properties = list(y = "numeric"))
+  expect_s3_class(text1("abc"), "text1")
+  expect_s3_class(text2("abc", y = 1), "text2")
+})
 
 # constructor -------------------------------------------------------------
-
-test_that("generates correct arguments from parent + properties",  {
-  # No arguments
-  args <- constructor_args(R7_object)
-  expect_equal(args$constructor, character())
-
-  # Includes properties
-  args <- constructor_args(R7_object, as_properties(list(x = "numeric")))
-  expect_equal(args$constructor, "x")
-
-  # unless they're dynamic
-  args <- constructor_args(R7_object,
-    as_properties(list(new_property("x", getter = function(x) 10)))
-  )
-  expect_equal(args$constructor, character())
-
-  # Includes parent properties
-  foo <- new_class("foo", properties = list(x = "numeric"))
-  args <- constructor_args(foo, as_properties(list(y = "numeric")))
-  expect_equal(args$constructor, c("x", "y"))
-  expect_equal(args$self, "y")
-  expect_equal(args$parent, "x")
-
-  # But only those in the constructor
-  foo <- new_class("foo",
-    properties = list(x = "numeric"),
-    constructor = function() new_object(x = 1)
-  )
-  args <- constructor_args(foo, as_properties(list(y = "numeric")))
-  expect_equal(args$constructor, "y")
-  expect_equal(args$self, "y")
-  expect_equal(args$parent, character())
-})
-
-test_that("generates meaningful constructors", {
-  expect_snapshot({
-    foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"))
-    foo@constructor
-
-    foo <- new_class("foo", parent = "character")
-    foo@constructor
-
-    foo2 <- new_class("foo2", parent = foo)
-    foo2@constructor
-  }, transform = scrub_environment)
-})

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -52,3 +52,26 @@ test_that("classes can use unions in properties", {
 
   expect_snapshot_error(my_class(name = 1))
 })
+
+test_that("generates meaningful constructors", {
+  expect_snapshot({
+    foo <- new_class("foo")
+    foo@constructor
+
+    foo <- new_class("foo", properties = list(x = "numeric", y = "numeric"))
+    foo@constructor
+
+    foo <- new_class("foo", parent = "character")
+    foo@constructor
+
+    foo2 <- new_class("foo2", parent = foo)
+    foo2@constructor
+
+    foo <- new_class("foo",
+      properties = list(x = "numeric", y = "numeric"),
+      constructor = function() new_object(x = 1, y = 2)
+    )
+    foo2 <- new_class("foo2", parent = foo, properties = list(z = "numeric"))
+    foo2@constructor
+  }, transform = scrub_environment)
+})

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -64,5 +64,3 @@ test_that("default constructor works", {
   expect_s3_class(text1("abc"), "text1")
   expect_s3_class(text2("abc", y = 1), "text2")
 })
-
-# constructor -------------------------------------------------------------

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -1,0 +1,45 @@
+test_that("generates correct arguments from parent + properties",  {
+  # No arguments
+  args <- constructor_args(R7_object)
+  expect_equal(args$constructor, character())
+
+  # Includes properties
+  args <- constructor_args(R7_object, as_properties(list(x = "numeric")))
+  expect_equal(args$constructor, "x")
+
+  # unless they're dynamic
+  args <- constructor_args(R7_object,
+    as_properties(list(new_property("x", getter = function(x) 10)))
+  )
+  expect_equal(args$constructor, character())
+
+  # Includes parent properties
+  foo <- new_class("foo", properties = list(x = "numeric"))
+  args <- constructor_args(foo, as_properties(list(y = "numeric")))
+  expect_equal(args$constructor, c("x", "y"))
+  expect_equal(args$self, "y")
+  expect_equal(args$parent, "x")
+
+  # But only those in the constructor
+  foo <- new_class("foo",
+    properties = list(x = "numeric"),
+    constructor = function() new_object(x = 1)
+  )
+  args <- constructor_args(foo, as_properties(list(y = "numeric")))
+  expect_equal(args$constructor, "y")
+  expect_equal(args$self, "y")
+  expect_equal(args$parent, character())
+})
+
+test_that("generates meaningful constructors", {
+  expect_snapshot({
+    new_constructor(R7_object, list())
+    new_constructor(R7_object, as_properties(list(x = "numeric", y = "numeric")))
+
+    foo <- new_class("foo", parent = "character")
+    new_constructor(foo, list())
+
+    foo2 <- new_class("foo2", parent = foo)
+    new_constructor(foo2, list())
+  }, transform = scrub_environment)
+})

--- a/tests/testthat/test-object.R
+++ b/tests/testthat/test-object.R
@@ -23,9 +23,6 @@ describe("new_object", {
   })
 
   it("can instantiate a new object that inherits from a basic type", {
-    x <- text()
-    expect_equal(x@.data, class_get("character")())
-
     y <- text("foo")
     expect_equal(y@.data, class_get("character")("foo"))
   })

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -143,9 +143,6 @@ test_that("property setters can set themselves", {
     )
   )
 
-  x <- foo()
-
-  x@bar <- "foo"
-
+  x <- foo(bar = "foo")
   expect_equal(x@bar, "foo-bar")
 })

--- a/vignettes/case_studies.Rmd
+++ b/vignettes/case_studies.Rmd
@@ -78,10 +78,7 @@ Classes can inherit from a parent class with `parent` and contain properties tha
 ```{r}
 Employee <- new_class("Employee",
   parent = Person,
-  properties = list(boss = "Person"),
-  constructor = function(..., boss) {
-    new_object(Person(...), boss = boss)
-  }
+  properties = list(boss = "Person")
 )
 
 x <- Employee(name = "John Smith", birthdate = "1992-10-11", boss = jane)


### PR DESCRIPTION
The default constructor gets one argument for each property, passing on to the parent as appropriate.

Fixes #102. Fixes #103.