### PR TITLE
Make base types more consistent

### DIFF
--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -94,7 +94,7 @@ class_inherits <- function(x, what) {
     s3 = !isS4(x) && inherits(x, what[[1]]),
     s4 = isS4(x) && methods::is(x, what),
     r7 = inherits(x, "R7_object") && inherits(x, what@name),
-    r7_base = inherits(x, what@name),
+    r7_base = what@name %in% .class2(x),
     r7_union = any(vlapply(what@classes, class_inherits, x = x))
   )
 }

--- a/R/class.R
+++ b/R/class.R
@@ -3,7 +3,12 @@ R7_class <- function(name, parent = R7_object, constructor = NULL, validator = f
 
   parent <- as_class(parent)
   if (is_union(parent) || isS4(parent)) {
-    stop("`parent` must be an R7 class, S3 class, or base type")
+    not <- if (is_union(parent)) "a class union" else "an S4 class"
+    stop(
+      sprintf(
+        "`parent` must be an R7 class, S3 class, or base type, not %s.", not),
+      call. = FALSE
+    )
   }
 
   # Combine properties from parent, overriding as needed

--- a/R/generic.R
+++ b/R/generic.R
@@ -21,7 +21,7 @@
 #' # A simple generic with methods for some base types and S3 classes
 #' type_of <- new_generic("type_of", signature = "x")
 #' method(type_of, "character") <- function(x, ...) "A character vector"
-#' method(type_of, "data.frame") <- function(x, ...) "A data frame"
+#' method(type_of, s3_class("data.frame")) <- function(x, ...) "A data frame"
 #' method(type_of, "function") <- function(x, ...) "A function"
 #'
 #' type_of(mtcars)

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,7 @@ global_variables <- function(names) {
 
 vlapply <- function(X, FUN, ...) vapply(X = X, FUN = FUN, FUN.VALUE = logical(1), ...)
 vcapply <- function(X, FUN, ...) vapply(X = X, FUN = FUN, FUN.VALUE = character(1), ...)
-`%||%` <- function(x, y) if (length(x) == 0 || (length(x) == 1 && !nzchar(x))) y else x
+`%||%` <- function(x, y) if (length(x) == 0) y else x
 
 collapse <- function(x, by) {
   paste(x, collapse = by)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,7 +16,7 @@ new_base_class <- function(name) {
   R7_class(name = name, constructor = function(.data) new_object(.data))
 }
 
-base_types <- setNames(, c("logical", "integer", "double", "numeric", "complex", "character", "factor", "raw", "function", "list", "data.frame", "environment"))
+base_types <- setNames(, c("logical", "integer", "double", "complex", "character", "raw", "function", "list", "expression", "environment"))
 
 base_classes <- lapply(base_types, new_base_class)
 base_classes[["NULL"]] <- new_base_class("NULL")
@@ -95,4 +95,10 @@ global_variables(c("name", "parent", "properties", "constructor", "validator"))
 .onAttach <- function(libname, pkgname) {
   env <- as.environment(paste0("package:", pkgname))
   env[[".conflicts.OK"]] <- TRUE
+}
+
+.onLoad <- function(...) {
+  base_classes$numeric <<- new_union("integer", "double")
+  base_classes$atomic <<- new_union("logical", base_classes$numeric, "complex", "character")
+  base_classes$vector <<- new_union(base_classes$atomic, "expression", "list")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,11 +16,13 @@ new_base_class <- function(name) {
   R7_class(name = name, constructor = function(.data) new_object(.data))
 }
 
-base_types <- setNames(, c("logical", "integer", "double", "complex", "character", "raw", "function", "list", "expression", "environment"))
-
+# Define simple base types with constructors. See .onLoad() for more
+base_types <- setNames(, c(
+  "logical", "integer", "double", "complex", "character", "raw",
+  "list", "expression",
+  "function", "environment"
+))
 base_classes <- lapply(base_types, new_base_class)
-base_classes[["NULL"]] <- new_base_class("NULL")
-
 base_constructors <- lapply(base_types, get)
 
 
@@ -98,6 +100,7 @@ global_variables(c("name", "parent", "properties", "constructor", "validator"))
 }
 
 .onLoad <- function(...) {
+  base_classes$`NULL` <- new_base_class("NULL")
   base_classes$numeric <<- new_union("integer", "double")
   base_classes$atomic <<- new_union("logical", base_classes$numeric, "complex", "character")
   base_classes$vector <<- new_union(base_classes$atomic, "expression", "list")

--- a/man/method.Rd
+++ b/man/method.Rd
@@ -33,11 +33,11 @@ interactively in order to see the implementation of a specific method.
 bizarro <- new_generic("bizarro", signature = "x")
 # Register some methods
 method(bizarro, "numeric") <- function(x, ...) rev(x)
-method(bizarro, "factor") <- function(x, ...) {
+method(bizarro, s3_class("factor")) <- function(x, ...) {
   levels(x) <- rev(levels(x))
   x
 }
-method(bizarro, "data.frame") <- function(x, ...) {
+method(bizarro, s3_class("data.frame")) <- function(x, ...) {
   x[] <- lapply(x, bizarro)
   rev(x)
 }
@@ -47,6 +47,6 @@ bizarro(1)
 
 # But it can be useful to explicitly retrieve a method in order to
 # inspect its implementation
-method(bizarro, list("numeric"))
-method(bizarro, list("factor"))
+method(bizarro, "double")
+method(bizarro, s3_class("factor"))
 }

--- a/man/new_generic.Rd
+++ b/man/new_generic.Rd
@@ -28,7 +28,7 @@ of one or more arguments (the \code{signature}). Create a new generic with
 # A simple generic with methods for some base types and S3 classes
 type_of <- new_generic("type_of", signature = "x")
 method(type_of, "character") <- function(x, ...) "A character vector"
-method(type_of, "data.frame") <- function(x, ...) "A data frame"
+method(type_of, s3_class("data.frame")) <- function(x, ...) "A data frame"
 method(type_of, "function") <- function(x, ...) "A function"
 
 type_of(mtcars)

--- a/src/code.c
+++ b/src/code.c
@@ -51,7 +51,7 @@ SEXP method_internal(SEXP table, SEXP signature, R_xlen_t signature_itr, SEXP ig
 SEXP get_class(SEXP object, SEXP envir) {
     static SEXP fun = NULL;
     if (fun == NULL) {
-      fun = Rf_findVarInFrame(R_BaseEnv, Rf_install("class"));
+      fun = Rf_findVarInFrame(R_BaseEnv, Rf_install(".class2"));
     }
     SEXP call = PROTECT(Rf_lang2(fun, object));
     SEXP res = Rf_eval(call, envir);

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -10,7 +10,7 @@
 
 # classes can use unions in properties
 
-    <my_class>@name must be of class <character> u <factor>, not <double>
+    <my_class>@name must be of class <integer> u <double>, not <character>
 
 # constructor  types check their values
 

--- a/tests/testthat/_snaps/method.md
+++ b/tests/testthat/_snaps/method.md
@@ -59,20 +59,20 @@
 # method lookup fails with an informative message for single classes
 
     Can't find method for generic `foo()` with classes:
-    - x: <character>
-    - y: <character>
+    - x: <logical>
+    - y: <list>
 
 ---
 
     Can't find method for generic `foo()` with classes:
-    - x: <character>
-    - y: NULL
+    - x: <logical>
+    - y: <>
 
 # method lookup fails with an informative message for multiple classes
 
     Can't find method for generic `foo()` with classes:
-    - x: <character>
-    - y: <character>
+    - x: <tbl_df>, <tbl>, <data.frame>
+    - y: <POSIXct>, <POSIXt>
 
 # R7_method printing
 

--- a/tests/testthat/_snaps/method.md
+++ b/tests/testthat/_snaps/method.md
@@ -14,6 +14,15 @@
 
     signature[[1]]: Can't find base class called 'blah'
 
+# new_method works if you pass a bare class union
+
+    Code
+      foo7
+    Output
+      <R7_generic> function (x, ...)  with 2 methods:
+      1: method(foo7, number)
+      2: method(foo7, text)
+
 # method_compatible throws errors if the functions are not compatible
 
     `method` must be consistent with <R7_generic> foo.

--- a/tests/testthat/_snaps/object.md
+++ b/tests/testthat/_snaps/object.md
@@ -37,9 +37,9 @@
       @name range
       @parent <R7_object>
       @properties
-       $start  <numeric>
-       $end    <numeric>
-       $length <numeric>
+       $start  <double>
+       $end    <double>
+       $length <double>
 
 # str with simple R7 objects work
 
@@ -57,7 +57,7 @@
     Output
       List of 2
        $ : <text/character/R7_object>  chr "b"
-       $ : <number/numeric/R7_object>  num 50
+       $ : <number/double/R7_object>  num 50
 
 # str R7 classes work
 
@@ -75,7 +75,7 @@
        ..  ..$ start :List of 4
        ..  .. ..$ name  : chr "start"
        ..  .. ..$ class : <R7_class/R7_object> function (.data)  
-       ..  .. .. ..- attr(*, "name")= chr "numeric"
+       ..  .. .. ..- attr(*, "name")= chr "double"
        ..  .. .. ..- attr(*, "parent")= <R7_class/R7_object> function ()  
        ..  .. .. .. ..- attr(*, "name")= chr "R7_object"
        ..  .. .. .. ..- attr(*, "properties")= list()
@@ -90,7 +90,7 @@
        ..  ..$ end   :List of 4
        ..  .. ..$ name  : chr "end"
        ..  .. ..$ class : <R7_class/R7_object> function (.data)  
-       ..  .. .. ..- attr(*, "name")= chr "numeric"
+       ..  .. .. ..- attr(*, "name")= chr "double"
        ..  .. .. ..- attr(*, "parent")= <R7_class/R7_object> function ()  
        ..  .. .. .. ..- attr(*, "name")= chr "R7_object"
        ..  .. .. .. ..- attr(*, "properties")= list()
@@ -105,7 +105,7 @@
        ..  ..$ length:List of 4
        ..  .. ..$ name  : chr "length"
        ..  .. ..$ class : <R7_class/R7_object> function (.data)  
-       ..  .. .. ..- attr(*, "name")= chr "numeric"
+       ..  .. .. ..- attr(*, "name")= chr "double"
        ..  .. .. ..- attr(*, "parent")= <R7_class/R7_object> function ()  
        ..  .. .. .. ..- attr(*, "name")= chr "R7_object"
        ..  .. .. .. ..- attr(*, "properties")= list()

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,5 +1,5 @@
 text <- new_class("text", parent = "character", constructor = function(text = character()) new_object(.data = text))
-number <- new_class("number", parent = "numeric", constructor = function(x) new_object(.data = x))
+number <- new_class("number", parent = "double", constructor = function(x) new_object(.data = x))
 
 range <- new_class("range",
   constructor = function(start, end) {
@@ -11,11 +11,11 @@ range <- new_class("range",
     }
   },
   properties = list(
-    start = "numeric",
-    end = "numeric",
+    start = "double",
+    end = "double",
     new_property(
       name = "length",
-      class = "numeric",
+      class = "double",
       getter = function(x) x@end - x@start,
       setter = function(x, value) {
         x@end <- x@start + value

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -107,6 +107,17 @@ test_that("can work with base types", {
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 
+test_that("class_inherits handles variation in class names", {
+  expect_true(class_inherits(1, base_classes$double))
+
+  expect_true(class_inherits(1L, base_classes$numeric))
+  expect_true(class_inherits(1, base_classes$numeric))
+
+  expect_true(class_inherits(function() {}, base_classes$`function`))
+  expect_true(class_inherits(sum, base_classes$`function`))
+  expect_true(class_inherits(`[`, base_classes$`function`))
+})
+
 test_that("can get class from base constructor", {
   expect_equal(as_class(character), base_classes$character)
   expect_equal(as_class(`function`), base_classes$`function`)

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -35,7 +35,7 @@ test_that("classes can inherit from base types", {
     expect_equal(typeof(obj@.data), type)
   }
 
-  foo <- new_class("foo", parent = "numeric", constructor = function(x = numeric()) new_object(x))
+  foo <- new_class("foo", parent = "double", constructor = function(x = numeric()) new_object(x))
   obj <- foo()
   expect_equal(typeof(obj@.data), "double")
 
@@ -52,22 +52,22 @@ test_that("can supply literal examples of base types", {
 })
 
 test_that("classes can use unions in properties", {
-  my_class <- new_class("my_class", properties = list(new_property(name = "name", new_union("character", "factor"))))
+  my_class <- new_class("my_class", properties = list(name = "numeric"))
 
-  expect_equal(my_class(name = "foo")@name, "foo")
-  expect_equal(my_class(name = factor("foo"))@name, factor("foo"))
+  expect_equal(my_class(name = 1.5)@name, 1.5)
+  expect_equal(my_class(name = 1L)@name, 1L)
 
-  expect_snapshot_error(my_class(name = 1))
+  expect_snapshot_error(my_class(name = "x"))
 })
 
 test_that("default constructor works", {
-  foo1 <- new_class("foo1", properties = list(x = "numeric"))
-  foo2 <- new_class("foo2", parent = foo1, properties = list(y = "numeric"))
+  foo1 <- new_class("foo1", properties = list(x = "double"))
+  foo2 <- new_class("foo2", parent = foo1, properties = list(y = "double"))
   expect_s3_class(foo1(x = 1), "foo1")
   expect_s3_class(foo2(x = 1, y = 2), "foo2")
 
   text1 <- new_class("text1", parent = "character")
-  text2 <- new_class("text2", parent = text1, properties = list(y = "numeric"))
+  text2 <- new_class("text2", parent = text1, properties = list(y = "double"))
   expect_s3_class(text1("abc"), "text1")
   expect_s3_class(text2("abc", y = 1), "text2")
 })

--- a/tests/testthat/test-method.R
+++ b/tests/testthat/test-method.R
@@ -101,6 +101,11 @@ test_that("new_method works if you pass a bare class union", {
 
   expect_equal(foo7(text("bar")), "foo-bar")
   expect_equal(foo7(number(1)), "foo-1")
+
+  # one method for each union component
+  expect_length(methods(foo7), 2)
+  # and methods printed nicely
+  expect_snapshot(foo7)
 })
 
 test_that("next_method works for single dispatch", {

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -22,7 +22,7 @@ The dispatch performance should be roughly on par with S3 and S4, though as this
 
 ```{r performance, cache = FALSE}
 text <- new_class("text", parent = "character", constructor = function(text) new_object(.data = text))
-number <- new_class("number", parent = "numeric", constructor = function(x) new_object(.data = x))
+number <- new_class("number", parent = "double", constructor = function(x) new_object(.data = x))
 
 x <- text("hi")
 y <- number(1)


### PR DESCRIPTION
Changes to base types:
* make numeric a union
* add new atomic and vector unions
* remove factor and data.frame S3 classes
* add expression base type

And includes a few quality of life improvements:

* Method dispatch failure now reports correct classes
* Methods created from union now have own names
* More explicit error when parent is a union

Fixes #77. Fixes #94. Built on top of #134.