### PR TITLE
Disambiguate dispatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Feb 2022
 
+* Dispatch now disambiguates between S4 and S3/R7, and, optionally, between
+  R7 classes in different packages (#48, #163).
+
 * When creating a class, unspecified properties are initialized with their 
   default value (#67). DISCUSS: to achieve this, the constructor arguments
   default to `missing_class`.

--- a/R/S4.R
+++ b/R/S4.R
@@ -33,16 +33,15 @@ S4_to_R7_class <- function(x, error_base = "") {
   }
 }
 
-# Find all non-virtual classes
 S4_class_dispatch <- function(x) {
   x <- methods::getClass(x)
   self <- S4_class_name(x)
 
-  # Find all extended classes
+  # Find class objects for super classes
   extends <- unname(methods::extends(x, fullInfo = TRUE))
   extends <- Filter(function(x) methods::is(x, "SClassExtension"), extends)
-
   classes <- lapply(extends, function(x) methods::getClass(x@superClass))
+
   # Remove virtual classes that aren't S3. This removes unions because R7
   # handles them in method registration, not dispatch.
   classes <- Filter(function(x) !x@virtual || is_oldClass(x), classes)

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -147,7 +147,7 @@ class_dispatch <- function(x) {
     NULL = c("NULL", "ANY"),
     missing = "MISSING",
     any = "ANY",
-    S4 = c(S4_strip_union(methods::extends(x)), "ANY"),
+    S4 = c(S4_class_dispatch(methods::extends(x)), "ANY"),
     R7 = c(x@name, class_dispatch(x@parent)),
     R7_base = c(x$class, "R7_object", "ANY"),
     R7_S3 = c(x$class, "R7_object", "ANY"),
@@ -161,7 +161,7 @@ class_register <- function(x) {
     NULL = "NULL",
     missing = "MISSING",
     any = "ANY",
-    S4 = as.character(x@className),
+    S4 = S4_class_name(x),
     R7 = x@name,
     R7_base = x$class,
     R7_S3 = x$class[[1]],
@@ -222,7 +222,7 @@ obj_dispatch <- function(x) {
   switch(obj_type(x),
     base = c(.class2(x), "ANY"),
     S3 = c(class(x), "ANY"),
-    S4 = c(S4_strip_union(methods::is(x)), "ANY"),
+    S4 = c(S4_class_dispatch(methods::getClass(class(x))), "ANY"),
     R7 = c(class(x), "ANY") # = class_dispatch(object_class(x))
   )
 }

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -132,7 +132,7 @@ class_desc <- function(x) {
     missing = "<MISSING>",
     any = "<ANY>",
     S4 = paste0("S4<", x@className, ">"),
-    R7 = paste0("<", x@name, ">"),
+    R7 = paste0("<", R7_class_name(x), ">"),
     R7_base = paste0("<", x$class, ">"),
     R7_union = oxford_or(unlist(lapply(x$classes, class_desc))),
     R7_S3 = paste0("S3<", paste0(x$class, collapse = "/"), ">"),
@@ -148,7 +148,7 @@ class_dispatch <- function(x) {
     missing = "MISSING",
     any = "ANY",
     S4 = c(S4_class_dispatch(methods::extends(x)), "ANY"),
-    R7 = c(x@name, class_dispatch(x@parent)),
+    R7 = c(R7_class_name(x), class_dispatch(x@parent)),
     R7_base = c(x$class, "R7_object", "ANY"),
     R7_S3 = c(x$class, "R7_object", "ANY"),
     stop("Unsupported")
@@ -162,7 +162,7 @@ class_register <- function(x) {
     missing = "MISSING",
     any = "ANY",
     S4 = S4_class_name(x),
-    R7 = x@name,
+    R7 = R7_class_name(x),
     R7_base = x$class,
     R7_S3 = x$class[[1]],
     stop("Unsupported")
@@ -176,7 +176,7 @@ class_deparse <- function(x) {
     missing = "missing_class",
     any = "any_class",
     S4 = as.character(x@className),
-    R7 = x@name,
+    R7 = R7_class_name(x),
     R7_base = encodeString(x$class, quote = '"'),
     R7_union = {
       classes <- vcapply(x$classes, class_deparse)
@@ -192,7 +192,7 @@ class_inherits <- function(x, what) {
     missing = FALSE,
     any = TRUE,
     S4 = isS4(x) && methods::is(x, what),
-    R7 = inherits(x, "R7_object") && inherits(x, what@name),
+    R7 = inherits(x, "R7_object") && inherits(x, R7_class_name(what)),
     R7_base = what$class %in% .class2(x),
     R7_union = any(vlapply(what$classes, class_inherits, x = x)),
     R7_S3 = !isS4(x) && is_prefix(what$class, class(x)),

--- a/R/class.R
+++ b/R/class.R
@@ -11,7 +11,11 @@
 #'   * The R7 class, like [R7_object].
 #'   * An S3 class wrapped by [new_S3_class()].
 #'   * A base type, like `logical`, `double`, or `character`.
-#'
+#' @param package Package name. It is good practice to set the package
+#'   name when exporting an R7 class from a package because it includes
+#'   the package name in the class name when it's used for dispatch. This
+#'   allows different packages to use the same name to refer to different
+#'   classes.
 #' @param constructor The constructor function. Advanced use only.
 #'
 #'   A custom constructor should call `new_object()` to create the R7 object.
@@ -84,6 +88,7 @@
 new_class <- function(
     name,
     parent = R7_object,
+    package = NULL,
     properties = list(),
     constructor = NULL,
     validator = NULL) {
@@ -97,6 +102,10 @@ new_class <- function(
          "`parent` must be an R7 class, S3 class, or base type, not %s.", class_friendly(parent)),
        call. = FALSE
      )
+  }
+
+  if (!is.null(package)) {
+    check_name(package)
   }
 
   if (!is.null(constructor) && !is.null(parent)) {
@@ -119,6 +128,7 @@ new_class <- function(
   # Must synchronise with prop_names
   attr(object, "name") <- name
   attr(object, "parent") <- parent
+  attr(object, "package") <- package
   attr(object, "properties") <- all_props
   attr(object, "constructor") <- constructor
   attr(object, "validator") <- validator
@@ -126,6 +136,11 @@ new_class <- function(
 
   global_variables(names(all_props))
   object
+}
+globalVariables(c("name", "parent", "package", "properties", "constructor", "validator"))
+
+R7_class_name <- function(x) {
+  paste(c(x@package, x@name), collapse = "::")
 }
 
 check_R7_constructor <- function(constructor) {

--- a/R/property.R
+++ b/R/property.R
@@ -90,12 +90,14 @@ new_property <- function(name, class = any_class, getter = NULL, setter = NULL, 
   out
 }
 
-check_name <- function(name) {
+check_name <- function(name, arg = deparse(substitute(name))) {
   if (length(name) != 1 || !is.character(name)) {
-    stop("`name` must be a single string", call. = FALSE)
+    msg <- sprintf("`%s` must be a single string", arg)
+    stop(msg, call. = FALSE)
   }
   if (is.na(name) || name == "") {
-    stop("`name` must not be \"\" or NA", call. = FALSE)
+    msg <- sprintf("`%s` must not be \"\" or NA", arg)
+    stop(msg, call. = FALSE)
   }
 }
 
@@ -252,7 +254,7 @@ prop_names <- function(object) {
 
   if (inherits(object, "R7_class")) {
     # R7_class isn't a R7_class (somewhat obviously) so we fake the property names
-    c("name", "parent", "properties", "constructor", "validator")
+    c("name", "parent", "package", "properties", "constructor", "validator")
   } else {
     class <- object_class(object)
     props <- attr(class, "properties", exact = TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,3 @@
-global_variables(c("name", "parent", "properties", "constructor", "validator"))
-
 #' Base R7 class
 #'
 #' @keywords internal

--- a/man/new_class.Rd
+++ b/man/new_class.Rd
@@ -8,6 +8,7 @@
 new_class(
   name,
   parent = R7_object,
+  package = NULL,
   properties = list(),
   constructor = NULL,
   validator = NULL
@@ -25,6 +26,12 @@ There are four options:
 \item An S3 class wrapped by \code{\link[=new_S3_class]{new_S3_class()}}.
 \item A base type, like \code{logical}, \code{double}, or \code{character}.
 }}
+
+\item{package}{Package name. It is good practice to set the package
+name when exporting an R7 class from a package because it includes
+the package name in the class name when it's used for dispatch. This
+allows different packages to use the same name to refer to different
+classes.}
 
 \item{properties}{A list specifying the properties (data) that
 every object of the class will possess. Each property can either be

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -15,6 +15,7 @@
       <foo2/foo1/R7_object> constructor
       @ name       :  chr "foo2"
       @ parent     :  <foo1/R7_object> constructor
+      @ package    :  NULL
       @ properties : List of 2
        .. $ x: <R7_property> 
        ..  ..$ name   :  chr "x"
@@ -46,6 +47,10 @@
       new_class("foo", 1)
     Error <simpleError>
       Can't convert `parent` to a valid class. Class specification must be an R7 class object, the result of `new_S3_class()`, an S4 class object, or a base constructor function, not a <double>.
+    Code
+      new_class("foo", package = 1)
+    Error <simpleError>
+      `package` must be a single string
     Code
       new_class("foo", constructor = 1)
     Error <simpleError>

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -1,6 +1,6 @@
 test_that("can work with classGenerators", {
   on.exit(S4_remove_classes("Foo"))
-  Foo <- setClass("Foo")
+  Foo <- setClass("Foo", where = globalenv())
   expect_equal(S4_to_R7_class(Foo), getClass("Foo"))
 })
 
@@ -12,17 +12,17 @@ test_that("converts S4 base classes to R7 base classes", {
 test_that("converts S4 unions to R7 unions", {
   on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3", "Union1", "Union2")))
 
-  setClass("Foo1", slots = "x")
-  setClass("Foo2", slots = "x")
+  setClass("Foo1", slots = "x", where = globalenv())
+  setClass("Foo2", slots = "x", where = globalenv())
 
-  setClassUnion("Union1", c("Foo1", "Foo2"))
+  setClassUnion("Union1", c("Foo1", "Foo2"), where = globalenv())
   expect_equal(
     S4_to_R7_class(getClass("Union1")),
     new_union(getClass("Foo1"), getClass("Foo2"))
   )
 
-  setClass("Foo3", slots = "x")
-  setClassUnion("Union2", c("Union1", "Foo3"))
+  setClass("Foo3", slots = "x", where = globalenv())
+  setClassUnion("Union2", c("Union1", "Foo3"), where = globalenv())
   expect_equal(
     S4_to_R7_class(getClass("Union2")),
     new_union(getClass("Foo1"), getClass("Foo2"), getClass("Foo3"))
@@ -41,26 +41,26 @@ test_that("errors on non-S4 classes", {
 describe("S4_class_dispatch", {
   it("returns name of base class", {
     on.exit(S4_remove_classes("Foo1"))
-    setClass("Foo1", slots = list("x" = "numeric"))
+    setClass("Foo1", slots = list("x" = "numeric"), where = globalenv())
     expect_equal(S4_class_dispatch("Foo1"), "S4/Foo1")
   })
 
   it("respects single inheritance hierarchy", {
     on.exit(S4_remove_classes(c("Foo1", "Foo2","Foo3")))
 
-    setClass("Foo1", slots = list("x" = "numeric"))
-    setClass("Foo2", contains = "Foo1")
-    setClass("Foo3", contains = "Foo2")
+    setClass("Foo1", slots = list("x" = "numeric"), where = globalenv())
+    setClass("Foo2", contains = "Foo1", where = globalenv())
+    setClass("Foo3", contains = "Foo2", where = globalenv())
     expect_equal(S4_class_dispatch("Foo3"), c("S4/Foo3", "S4/Foo2", "S4/Foo1"))
   })
 
   it("performs breadth first search for multiple dispatch", {
     on.exit(S4_remove_classes(c("Foo1a", "Foo1b","Foo2a", "Foo2b", "Foo3")))
-    setClass("Foo1a", slots = list("x" = "numeric"))
-    setClass("Foo1b", contains = "Foo1a")
-    setClass("Foo2a", slots = list("x" = "numeric"))
-    setClass("Foo2b", contains = "Foo2a")
-    setClass("Foo3", contains = c("Foo1b", "Foo2b"))
+    setClass("Foo1a", slots = list("x" = "numeric"), where = globalenv())
+    setClass("Foo1b", contains = "Foo1a", where = globalenv())
+    setClass("Foo2a", slots = list("x" = "numeric"), where = globalenv())
+    setClass("Foo2b", contains = "Foo2a", where = globalenv())
+    setClass("Foo3", contains = c("Foo1b", "Foo2b"), where = globalenv())
     expect_equal(
       S4_class_dispatch("Foo3"),
       c("S4/Foo3", "S4/Foo1b", "S4/Foo2b", "S4/Foo1a", "S4/Foo2a")
@@ -69,25 +69,25 @@ describe("S4_class_dispatch", {
 
   it("handles extensions of base classes", {
     on.exit(S4_remove_classes("Foo1"))
-    setClass("Foo1", contains = "character")
+    setClass("Foo1", contains = "character", where = globalenv())
     expect_equal(S4_class_dispatch("Foo1"), c("S4/Foo1", "character"))
   })
 
   it("handles extensions of S3 classes", {
     on.exit(S4_remove_classes(c("Soo1", "Foo2", "Foo3")))
 
-    setOldClass(c("Soo1", "Soo"))
-    setClass("Foo2", contains = "Soo1")
-    setClass("Foo3", contains = "Foo2")
+    setOldClass(c("Soo1", "Soo"), where = globalenv())
+    setClass("Foo2", contains = "Soo1", where = globalenv())
+    setClass("Foo3", contains = "Foo2", where = globalenv())
     expect_equal(S4_class_dispatch("Foo3"), c("S4/Foo3", "S4/Foo2", "Soo1", "Soo"))
   })
 
   it("ignores unions", {
     on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3")))
 
-    setClass("Foo1", slots = list("x" = "numeric"))
-    setClass("Foo2", slots = list("x" = "numeric"))
-    setClassUnion("Foo3", c("Foo1", "Foo2"))
+    setClass("Foo1", slots = list("x" = "numeric"), where = globalenv())
+    setClass("Foo2", slots = list("x" = "numeric"), where = globalenv())
+    setClassUnion("Foo3", c("Foo1", "Foo2"), where = globalenv())
 
     expect_equal(S4_class_dispatch("Foo1"), "S4/Foo1")
     expect_equal(S4_class_dispatch("Foo2"), "S4/Foo2")
@@ -95,7 +95,7 @@ describe("S4_class_dispatch", {
 
   it("captures explicit package name", {
     on.exit(S4_remove_classes("Foo1"))
-    setClass("Foo1", package = "pkg")
+    setClass("Foo1", package = "pkg", where = globalenv())
     expect_equal(S4_class_dispatch("Foo1"), "S4/pkg::Foo1")
   })
 
@@ -107,6 +107,4 @@ describe("S4_class_dispatch", {
     setClass("Foo1", where = env)
     expect_equal(S4_class_dispatch("Foo1"), "S4/mypkg::Foo1")
   })
-
 })
-

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -1,4 +1,5 @@
 test_that("can work with classGenerators", {
+  on.exit(S4_remove_classes("Foo"))
   Foo <- setClass("Foo")
   expect_equal(S4_to_R7_class(Foo), getClass("Foo"))
 })
@@ -9,6 +10,8 @@ test_that("converts S4 base classes to R7 base classes", {
 })
 
 test_that("converts S4 unions to R7 unions", {
+  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3", "Union1", "Union2")))
+
   setClass("Foo1", slots = "x")
   setClass("Foo2", slots = "x")
 
@@ -68,6 +71,15 @@ describe("S4_class_dispatch", {
     on.exit(S4_remove_classes("Foo1"))
     setClass("Foo1", contains = "character")
     expect_equal(S4_class_dispatch("Foo1"), c("S4/Foo1", "character"))
+  })
+
+  it("handles extensions of S3 classes", {
+    on.exit(S4_remove_classes(c("Soo1", "Foo2", "Foo3")))
+
+    setOldClass(c("Soo1", "Soo"))
+    setClass("Foo2", contains = "Soo1")
+    setClass("Foo3", contains = "Foo2")
+    expect_equal(S4_class_dispatch("Foo3"), c("S4/Foo3", "S4/Foo2", "Soo1", "Soo"))
   })
 
   it("ignores unions", {

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -16,6 +16,24 @@ test_that("can work with R7 classes", {
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 
+test_that("can work with packages R7 classes", {
+  klass <- new_class("klass", package = "pkg")
+  expect_equal(as_class(klass), klass)
+
+  expect_equal(class_type(klass), "R7")
+  expect_equal(class_dispatch(klass), c("pkg::klass", "R7_object", "ANY"))
+  expect_equal(class_register(klass), "pkg::klass")
+  expect_equal(class_construct(klass), klass())
+  expect_equal(class_desc(klass), "<pkg::klass>")
+  expect_equal(class_deparse(klass), "pkg::klass")
+
+  obj <- klass()
+  expect_equal(obj_type(obj), "R7")
+  expect_equal(obj_desc(obj), "<pkg::klass>")
+  expect_equal(obj_dispatch(obj), c("pkg::klass", "R7_object", "ANY"))
+  expect_equal(class_inherits(obj, klass), TRUE)
+})
+
 test_that("can work with unions", {
   text <- new_class("text", character)
   number <- new_class("number", double)

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -16,7 +16,7 @@ test_that("can work with R7 classes", {
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 
-test_that("can work with packages R7 classes", {
+test_that("can work with R7 classes in packages", {
   klass <- new_class("klass", package = "pkg")
   expect_equal(as_class(klass), klass)
 

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -136,62 +136,26 @@ test_that("can work with R7 classes that extend S3 classes", {
 # S4 ----------------------------------------------------------------------
 
 test_that("can work with S4 classes", {
-  methods::setClass("Range", slots = c(start = "numeric", end = "numeric"))
-  klass <- methods::getClass("Range")
+  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3", "Foo4")))
+
+  methods::setClass("Foo1", contains = "character", where = globalenv())
+  methods::setClass("Foo2", contains = "Foo1", where = globalenv())
+  methods::setClass("Foo3", slots = list(x = "numeric"), where = globalenv())
+  methods::setClass("Foo4", contains = c("Foo2", "Foo3"), where = globalenv())
+
+  klass <- methods::getClass("Foo4")
 
   expect_equal(class_type(klass), "S4")
-  expect_equal(class_dispatch(klass), c("Range", "ANY"))
-  expect_equal(class_register(klass), "Range")
-  expect_s4_class(class_construct(klass, start = 1, end = 2), "Range")
-  expect_equal(class_desc(klass), "S4<Range>")
-  expect_equal(class_deparse(klass), "Range")
+  expect_equal(class_dispatch(klass), c("S4/Foo4", "S4/Foo2", "S4/Foo3", "S4/Foo1", "character", "ANY"))
+  expect_equal(class_register(klass), "S4/Foo4")
+  expect_s4_class(class_construct(klass, 1, x = 2), "Foo4")
+  expect_equal(class_desc(klass), "S4<Foo4>")
+  expect_equal(class_deparse(klass), "Foo4")
 
-  obj <- methods::new(klass, start = 1, end = 1)
+  obj <- methods::new(klass, 1, x = 2)
   expect_equal(obj_type(obj), "S4")
-  expect_equal(obj_desc(obj), "S4<Range>")
-  expect_equal(obj_dispatch(obj), c("Range", "ANY"))
-  expect_equal(class_inherits(obj, klass), TRUE)
-})
-
-test_that("can work with S4 subclasses", {
-  methods::setClass("Foo1", slots = c(start = "numeric", end = "numeric"))
-  methods::setClass("Foo2", contains = "Foo1")
-  klass <- methods::getClass("Foo2")
-
-  expect_equal(class_type(klass), "S4")
-  expect_equal(class_dispatch(klass), c("Foo2", "Foo1", "ANY"))
-  expect_equal(class_register(klass), "Foo2")
-
-  obj <- methods::new(klass, start = 1, end = 1)
-  expect_equal(obj_dispatch(obj), c("Foo2", "Foo1", "ANY"))
-  expect_equal(class_inherits(obj, klass), TRUE)
-})
-
-test_that("can work with S4 subclasses of base classes", {
-  methods::setClass("Foo3", contains = "character")
-  klass <- methods::getClass("Foo3")
-
-  expect_equal(class_type(klass), "S4")
-  expect_equal(class_dispatch(klass), c("Foo3", "character", "ANY"))
-  expect_equal(class_register(klass), "Foo3")
-
-  obj <- methods::new(klass, "x")
-  expect_equal(obj_dispatch(obj), c("Foo3", "character", "ANY"))
-  expect_equal(class_inherits(obj, klass), TRUE)
-})
-
-test_that("can work with S4 multiple inheritance", {
-  methods::setClass("Foo4", contains = "character")
-  methods::setClass("Foo5")
-  methods::setClass("Foo6", contains = c("Foo4", "Foo5"))
-  klass <- methods::getClass("Foo6")
-
-  expect_equal(class_type(klass), "S4")
-  expect_equal(class_dispatch(klass), c("Foo6", "Foo4", "Foo5", "character", "ANY"))
-  expect_equal(class_register(klass), "Foo6")
-
-  obj <- methods::new(klass, "x")
-  expect_equal(obj_dispatch(obj), c("Foo6", "Foo4", "Foo5", "character", "ANY"))
+  expect_equal(obj_desc(obj), "S4<Foo4>")
+  expect_equal(obj_dispatch(obj), class_dispatch(klass))
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -1,6 +1,6 @@
 describe("R7 classes", {
   it("possess expected properties", {
-    foo <- new_class("foo", validator = function(self) NULL)
+    foo <- new_class("foo", package = "R7", validator = function(self) NULL)
 
     expect_equal(prop_names(foo), setdiff(names(attributes(foo)), "class"))
     expect_type(foo@name, "character")
@@ -27,6 +27,8 @@ describe("R7 classes", {
     expect_snapshot(error = TRUE, {
       new_class(1)
       new_class("foo", 1)
+
+      new_class("foo", package = 1)
 
       new_class("foo", constructor = 1)
       new_class("foo", constructor = function() {})


### PR DESCRIPTION
I think this is the minimal set of changes to disambiguate between:

* S4 vs R7/S3/base cases: `S4/foo` vs `foo`
* S4 classes with same name in different packages: `S4/pkgA::foo` vs `S4/pkgB::foo`
* R7 classes with same name in difference packages: `pkgA::foo` vs `pkgB::foo`

I went back and forth a bit on the separator, but ultimately I think `::` makes the most sense as running `pkg::class` will typically get you the class.

Fixes #48. Fixes #163