### PR TITLE
Standardise base dispatch

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -1,4 +1,6 @@
-new_base_class <- function(name, type = name) {
+new_base_class <- function(name) {
+  force(name)
+
   constructor <- function(.data = missing_class) {
     if (is_missing_class(.data)) {
       .data <- base_default(name)
@@ -6,10 +8,9 @@ new_base_class <- function(name, type = name) {
     .data
   }
 
-  force(type)
   validator <- function(object) {
-    if (!typeof(object) %in% type) {
-      sprintf("Underlying data must be <%s> not <%s>", paste0(type, collapse = "/"), typeof(object))
+    if (base_class(object) != name) {
+      sprintf("Underlying data must be <%s> not <%s>", name, base_class(object))
     }
   }
 
@@ -63,6 +64,6 @@ base_classes <- list(
   list = new_base_class("list"),
   expression = new_base_class("expression"),
 
-  `function` = new_base_class("function", c("closure", "special", "builtin")),
+  `function` = new_base_class("function"),
   environment = new_base_class("environment")
 )

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -195,7 +195,7 @@ class_inherits <- function(x, what) {
     any = TRUE,
     S4 = isS4(x) && methods::is(x, what),
     R7 = inherits(x, "R7_object") && inherits(x, R7_class_name(what)),
-    R7_base = what$class %in% .class2(x),
+    R7_base = what$class == base_class(x),
     R7_union = any(vlapply(what$classes, class_inherits, x = x)),
     R7_S3 = !isS4(x) && is_prefix(what$class, class(x)),
   )
@@ -222,10 +222,20 @@ obj_desc <- function(x) {
 }
 obj_dispatch <- function(x) {
   switch(obj_type(x),
-    base = c(.class2(x), "ANY"),
+    base = c(base_class(x), "ANY"),
     S3 = c(class(x), "ANY"),
     S4 = c(S4_class_dispatch(methods::getClass(class(x))), "ANY"),
     R7 = c(class(x), "ANY") # = class_dispatch(R7_class(x))
+  )
+}
+
+base_class <- function(x) {
+  switch(typeof(x),
+    closure = "function",
+    special = "function",
+    builtin = "function",
+    language = "call",
+    typeof(x)
   )
 }
 

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -113,6 +113,23 @@ test_that("can get class from base constructor", {
   expect_snapshot_error(as_class(mean))
 })
 
+test_that("dispatch for base objects use underlying type", {
+  expect_equal(obj_dispatch(1), c("double", "ANY"))
+  expect_equal(obj_dispatch(1L), c("integer", "ANY"))
+
+  expect_equal(obj_dispatch(matrix(1)), c("double", "ANY"))
+  expect_equal(obj_dispatch(matrix(1L)), c("integer", "ANY"))
+
+  expect_equal(obj_dispatch(array(1)), c("double", "ANY"))
+  expect_equal(obj_dispatch(array(1L)), c("integer", "ANY"))
+
+  expect_equal(obj_dispatch(function() {}), c("function", "ANY"))
+  expect_equal(obj_dispatch(sum), c("function", "ANY"))
+  expect_equal(obj_dispatch(`[`), c("function", "ANY"))
+
+  expect_equal(obj_dispatch(quote({})), c("call", "ANY"))
+})
+
 # S3 ----------------------------------------------------------------------
 
 test_that("can work with S3 classes", {


### PR DESCRIPTION
* New base_class() helper is a thin wrapper around typeof()
* No longer uses numeric in dispatch
* No longer uses matrix or array in dispatch; this hasn't been thought through yet, so better to leave off for now.

Fixes #197