### PR TITLE
Move handling of ANY into C

### DIFF
--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -124,17 +124,17 @@ class_desc <- function(x) {
 # Vector of class names; used in method introspection
 class_dispatch <- function(x) {
   if (is_class(x) && x@name == "R7_object") {
-    return(c("R7_object", "ANY"))
+    return("R7_object")
   }
 
   switch(class_type(x),
-    NULL = c("NULL", "ANY"),
+    NULL = "NULL",
     missing = "MISSING",
-    any = "ANY",
-    S4 = c(S4_class_dispatch(methods::extends(x)), "ANY"),
+    any = character(),
+    S4 = S4_class_dispatch(methods::extends(x)),
     R7 = c(R7_class_name(x), class_dispatch(x@parent)),
-    R7_base = c(x$class, "R7_object", "ANY"),
-    R7_S3 = c(x$class, "R7_object", "ANY"),
+    R7_base = c(x$class, "R7_object"),
+    R7_S3 = c(x$class, "R7_object"),
     stop("Unsupported")
   )
 }
@@ -207,10 +207,10 @@ obj_desc <- function(x) {
 }
 obj_dispatch <- function(x) {
   switch(obj_type(x),
-    base = c(base_class(x), "ANY"),
-    S3 = c(class(x), "ANY"),
-    S4 = c(S4_class_dispatch(methods::getClass(class(x))), "ANY"),
-    R7 = c(class(x), "ANY") # = class_dispatch(R7_class(x))
+    base = base_class(x),
+    S3 = class(x),
+    S4 = S4_class_dispatch(methods::getClass(class(x))),
+    R7 = class(x) # = class_dispatch(R7_class(x))
   )
 }
 

--- a/R/class.R
+++ b/R/class.R
@@ -184,7 +184,7 @@ print.R7_class <- function(x, ...) {
 #' @export
 str.R7_class <- function(object, ..., nest.lev = 0) {
   cat(if (nest.lev > 0) " ")
-  cat("<", paste0(setdiff(class_dispatch(object), "ANY"), collapse = "/"), "> constructor", sep = "")
+  cat("<", paste0(class_dispatch(object), collapse = "/"), "> constructor", sep = "")
   cat("\n")
 
   if (nest.lev == 0) {
@@ -233,7 +233,7 @@ new_object <- function(.parent, ...) {
 
   object <- .parent %||% class_construct(class@parent)
   attr(object, "R7_class") <- class
-  class(object) <- setdiff(class_dispatch(class), "ANY")
+  class(object) <- class_dispatch(class)
 
   for (nme in nms) {
     prop(object, nme, check = FALSE) <- args[[nme]]

--- a/R/convert.R
+++ b/R/convert.R
@@ -58,7 +58,7 @@ convert <- function(from, to, ...) {
     } else if (is_class(to)) {
       from <- zap_attr(from, setdiff(from_props, names(to@properties)))
       attr(from, "R7_class") <- to
-      class(from) <- setdiff(class_dispatch(to), "ANY")
+      class(from) <- class_dispatch(to)
     } else {
       stop("Unreachable")
     }

--- a/R/method-introspect.R
+++ b/R/method-introspect.R
@@ -62,6 +62,7 @@ method <- function(generic, class = NULL, object = NULL) {
 #' method_explain(add, list(foo2, foo2))
 method_explain <- function(generic, class = NULL, object = NULL) {
   dispatch <- as_dispatch(generic, class = class, object = object)
+  dispatch <- lapply(dispatch, c, "ANY")
 
   grid <- as.matrix(rev(do.call("expand.grid", rev(dispatch))))
   colnames(grid) <- generic@dispatch_args

--- a/src/init.c
+++ b/src/init.c
@@ -18,6 +18,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 SEXP parent_sym;
 SEXP name_sym;
+SEXP ANY_sym;
 
 void R_init_R7(DllInfo *dll)
 {
@@ -25,4 +26,5 @@ void R_init_R7(DllInfo *dll)
     R_useDynamicSymbols(dll, FALSE);
     parent_sym = Rf_install("parent");
     name_sym = Rf_install("name");
+    ANY_sym = Rf_install("ANY");
 }

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -4,6 +4,7 @@
 
 extern SEXP parent_sym;
 extern SEXP name_sym;
+extern SEXP ANY_sym;
 
 // Recursively walk through method table to perform iterated dispatch
 SEXP method_rec(SEXP table, SEXP signature, R_xlen_t signature_itr) {
@@ -23,6 +24,16 @@ SEXP method_rec(SEXP table, SEXP signature, R_xlen_t signature_itr) {
       return val;
     }
   }
+
+  // ANY fallback
+  SEXP val = Rf_findVarInFrame(table, ANY_sym);
+  if (TYPEOF(val) == ENVSXP) {
+    val = method_rec(val, signature, signature_itr + 1);
+  }
+  if (TYPEOF(val) == CLOSXP) {
+    return val;
+  }
+
   return R_NilValue;
 }
 

--- a/tests/testthat/_snaps/convert.md
+++ b/tests/testthat/_snaps/convert.md
@@ -4,6 +4,6 @@
       convert(obj, to = class_double)
     Error <simpleError>
       Can't find method for generic `convert()` with dispatch classes:
-      - from: converttest, R7_object, ANY
+      - from: converttest, R7_object
       - to  : double
 

--- a/tests/testthat/_snaps/method-dispatch.md
+++ b/tests/testthat/_snaps/method-dispatch.md
@@ -5,18 +5,18 @@
 # method lookup fails with informative messages
 
     Can't find method for generic `foo()` with dispatch classes:
-    - x: logical, ANY
+    - x: logical
     - y: MISSING
 
 ---
 
     Can't find method for generic `foo()` with dispatch classes:
-    - x: logical, ANY
-    - y: list, ANY
+    - x: logical
+    - y: list
 
 ---
 
     Can't find method for generic `foo()` with dispatch classes:
-    - x: tbl_df, tbl, data.frame, ANY
-    - y: POSIXct, POSIXt, ANY
+    - x: tbl_df, tbl, data.frame
+    - y: POSIXct, POSIXt
 

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -3,7 +3,7 @@ test_that("can work with R7 classes", {
   expect_equal(as_class(klass), klass)
 
   expect_equal(class_type(klass), "R7")
-  expect_equal(class_dispatch(klass), c("klass", "R7_object", "ANY"))
+  expect_equal(class_dispatch(klass), c("klass", "R7_object"))
   expect_equal(class_register(klass), "klass")
   expect_equal(class_construct(klass), klass())
   expect_equal(class_desc(klass), "<klass>")
@@ -12,7 +12,7 @@ test_that("can work with R7 classes", {
   obj <- klass()
   expect_equal(obj_type(obj), "R7")
   expect_equal(obj_desc(obj), "<klass>")
-  expect_equal(obj_dispatch(obj), c("klass", "R7_object", "ANY"))
+  expect_equal(obj_dispatch(obj), c("klass", "R7_object"))
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 
@@ -21,7 +21,7 @@ test_that("can work with R7 classes in packages", {
   expect_equal(as_class(klass), klass)
 
   expect_equal(class_type(klass), "R7")
-  expect_equal(class_dispatch(klass), c("pkg::klass", "R7_object", "ANY"))
+  expect_equal(class_dispatch(klass), c("pkg::klass", "R7_object"))
   expect_equal(class_register(klass), "pkg::klass")
   expect_equal(class_construct(klass), klass())
   expect_equal(class_desc(klass), "<pkg::klass>")
@@ -30,7 +30,7 @@ test_that("can work with R7 classes in packages", {
   obj <- klass()
   expect_equal(obj_type(obj), "R7")
   expect_equal(obj_desc(obj), "<pkg::klass>")
-  expect_equal(obj_dispatch(obj), c("pkg::klass", "R7_object", "ANY"))
+  expect_equal(obj_dispatch(obj), c("pkg::klass", "R7_object"))
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 
@@ -57,7 +57,7 @@ test_that("handles NULL", {
   expect_equal(as_class(NULL), NULL)
 
   expect_equal(class_type(NULL), "NULL")
-  expect_equal(class_dispatch(NULL), c("NULL", "ANY"))
+  expect_equal(class_dispatch(NULL), "NULL")
   expect_equal(class_register(NULL), "NULL")
   expect_equal(class_construct(NULL), NULL)
   expect_equal(class_desc(NULL), "<NULL>")
@@ -65,7 +65,7 @@ test_that("handles NULL", {
 
   expect_equal(obj_type(NULL), "base")
   expect_equal(obj_desc(NULL), "<NULL>")
-  expect_equal(obj_dispatch(NULL), c("NULL", "ANY"))
+  expect_equal(obj_dispatch(NULL), "NULL")
   expect_equal(class_inherits("x", NULL), FALSE)
   expect_equal(class_inherits(NULL, NULL), TRUE)
 })
@@ -75,7 +75,7 @@ test_that("handles NULL", {
 test_that("can work with base types", {
   klass <- class_character
   expect_equal(class_type(klass), "R7_base")
-  expect_equal(class_dispatch(klass), c("character", "R7_object", "ANY"))
+  expect_equal(class_dispatch(klass), c("character", "R7_object"))
   expect_equal(class_register(klass), "character")
   expect_equal(class_desc(klass), "<character>")
   expect_equal(class_construct(klass, "x"), "x")
@@ -84,7 +84,7 @@ test_that("can work with base types", {
   obj <- "x"
   expect_equal(obj_type(obj), "base")
   expect_equal(obj_desc(obj), "<character>")
-  expect_equal(obj_dispatch(obj), c("character", "ANY"))
+  expect_equal(obj_dispatch(obj), "character")
   expect_equal(class_inherits(obj, klass), TRUE)
 })
 
@@ -103,20 +103,20 @@ test_that("class_inherits handles variation in class names", {
 })
 
 test_that("dispatch for base objects use underlying type", {
-  expect_equal(obj_dispatch(1), c("double", "ANY"))
-  expect_equal(obj_dispatch(1L), c("integer", "ANY"))
+  expect_equal(obj_dispatch(1), "double")
+  expect_equal(obj_dispatch(1L), "integer")
 
-  expect_equal(obj_dispatch(matrix(1)), c("double", "ANY"))
-  expect_equal(obj_dispatch(matrix(1L)), c("integer", "ANY"))
+  expect_equal(obj_dispatch(matrix(1)), "double")
+  expect_equal(obj_dispatch(matrix(1L)), "integer")
 
-  expect_equal(obj_dispatch(array(1)), c("double", "ANY"))
-  expect_equal(obj_dispatch(array(1L)), c("integer", "ANY"))
+  expect_equal(obj_dispatch(array(1)), "double")
+  expect_equal(obj_dispatch(array(1L)), "integer")
 
-  expect_equal(obj_dispatch(function() {}), c("function", "ANY"))
-  expect_equal(obj_dispatch(sum), c("function", "ANY"))
-  expect_equal(obj_dispatch(`[`), c("function", "ANY"))
+  expect_equal(obj_dispatch(function() {}), "function")
+  expect_equal(obj_dispatch(sum), "function")
+  expect_equal(obj_dispatch(`[`), "function")
 
-  expect_equal(obj_dispatch(quote({})), c("call", "ANY"))
+  expect_equal(obj_dispatch(quote({})), "call")
 })
 
 # S3 ----------------------------------------------------------------------
@@ -128,7 +128,7 @@ test_that("can work with S3 classes", {
   expect_equal(as_class(klass), klass)
 
   expect_equal(class_type(klass), "R7_S3")
-  expect_equal(class_dispatch(klass), c("ordered", "factor", "R7_object", "ANY"))
+  expect_equal(class_dispatch(klass), c("ordered", "factor", "R7_object"))
   expect_equal(class_register(klass), "ordered")
   expect_equal(class_desc(klass), "S3<ordered/factor>")
   expect_equal(class_construct(klass), ordered(numeric()))
@@ -137,7 +137,7 @@ test_that("can work with S3 classes", {
   obj <- ordered(integer())
   expect_equal(obj_type(obj), "S3")
   expect_equal(obj_desc(obj), "S3<ordered/factor>")
-  expect_equal(obj_dispatch(obj), c("ordered", "factor", "ANY"))
+  expect_equal(obj_dispatch(obj), c("ordered", "factor"))
   expect_equal(class_inherits(obj, klass), TRUE)
   expect_equal(class_inherits(factor(), klass), FALSE)
 })
@@ -147,13 +147,13 @@ test_that("can work with R7 classes that extend S3 classes", {
   Date2 <- new_class("Date2", parent = Date, properties = list(x = class_numeric))
 
   expect_equal(class_type(Date2), "R7")
-  expect_equal(class_dispatch(Date2), c("Date2", "Date", "R7_object", "ANY"))
+  expect_equal(class_dispatch(Date2), c("Date2", "Date", "R7_object"))
   expect_equal(class_register(Date2), "Date2")
 
   obj <- Date2(x = 1)
   expect_equal(obj_type(obj), "R7")
   expect_equal(obj_desc(obj), "<Date2>")
-  expect_equal(obj_dispatch(obj), c("Date2", "Date", "R7_object", "ANY"))
+  expect_equal(obj_dispatch(obj), c("Date2", "Date", "R7_object"))
   expect_equal(class_inherits(.Date(1), Date), TRUE)
   expect_equal(class_inherits(obj, Date), TRUE)
   expect_equal(class_inherits(obj, Date2), TRUE)
@@ -172,7 +172,7 @@ test_that("can work with S4 classes", {
   klass <- methods::getClass("Foo4")
 
   expect_equal(class_type(klass), "S4")
-  expect_equal(class_dispatch(klass), c("S4/Foo4", "S4/Foo2", "S4/Foo3", "S4/Foo1", "character", "ANY"))
+  expect_equal(class_dispatch(klass), c("S4/Foo4", "S4/Foo2", "S4/Foo3", "S4/Foo1", "character"))
   expect_equal(class_register(klass), "S4/Foo4")
   expect_s4_class(class_construct(klass, 1, x = 2), "Foo4")
   expect_equal(class_desc(klass), "S4<Foo4>")

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -2,11 +2,12 @@ describe("single dispatch", {
   foo <- new_generic("foo", "x")
 
   it("works for specials", {
-    method(foo, class_missing) <- function(x) "missing"
     method(foo, class_any) <- function(x) "fallback"
-
-    expect_equal(foo(), "missing")
+    expect_equal(foo(), "fallback")
     expect_equal(foo(1), "fallback")
+
+    method(foo, class_missing) <- function(x) "missing"
+    expect_equal(foo(), "missing")
   })
 
   it("works for base types", {


### PR DESCRIPTION
Rather than including in class_dispatch(). This also ensures that missing arguments also look for ANY methods, so fixes #218.

@DavisVaughan what do you think? This feels like a nice simplification to me.