### PR TITLE
Fix check_is_R7 error message for non-R7 objects.

### DIFF
--- a/R/inherits.R
+++ b/R/inherits.R
@@ -30,7 +30,7 @@ R7_inherits <- function(x, class) {
 check_is_R7 <- function(x, class = NULL, arg = deparse(substitute(x))) {
   if (is.null(class)) {
     if (!inherits(x, "R7_object")) {
-      msg <- sprintf("`%s` must be an <R7_object>, not a %s", arg, class_desc(class), obj_desc(x))
+      msg <- sprintf("`%s` must be an <R7_object>, not a %s", arg, obj_desc(x))
       stop(msg, call. = FALSE)
     }
   } else {

--- a/tests/testthat/_snaps/inherits.md
+++ b/tests/testthat/_snaps/inherits.md
@@ -14,3 +14,10 @@
     Error <simpleError>
       `foo1()` must be a <foo2>, not a <foo1>
 
+---
+
+    Code
+      check_is_R7("a")
+    Error <simpleError>
+      `"a"` must be an <R7_object>, not a <character>
+

--- a/tests/testthat/test-inherits.R
+++ b/tests/testthat/test-inherits.R
@@ -17,4 +17,5 @@ test_that("throws informative error", {
     foo2 <- new_class("foo2")
     check_is_R7(foo1(), foo2)
   })
+  expect_snapshot(error = TRUE, check_is_R7("a"))
 })

--- a/tests/testthat/test-inherits.R
+++ b/tests/testthat/test-inherits.R
@@ -17,5 +17,5 @@ test_that("throws informative error", {
     foo2 <- new_class("foo2")
     check_is_R7(foo1(), foo2)
   })
-  expect_snapshot(error = TRUE, check_is_R7("a"))
+  expect_snapshot(check_is_R7("a"), error = TRUE)
 })


### PR DESCRIPTION
The sprintf had an extra argument (leftover from copy/paste of the other error message).