### PR TITLE
Respect visibility of method return values

### DIFF
--- a/R/method-dispatch.R
+++ b/R/method-dispatch.R
@@ -14,5 +14,6 @@ method_lookup_error <- function(name, args, signatures) {
 #' @order 2
 #' @export
 R7_dispatch <- function() {
-  .Call(method_call_, sys.call(-1), sys.function(-1), sys.frame(-1))
+  R7_dispatched_call <- .Call(method_call_, sys.call(-1), sys.function(-1), sys.frame(-1))
+  eval(R7_dispatched_call, envir = sys.frame(-1))
 }

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -164,9 +164,6 @@ SEXP method_call_(SEXP call, SEXP generic, SEXP envir) {
   SEXP m = method_(generic, dispatch_classes, Rf_ScalarLogical(1));
   SETCAR(mcall, m);
 
-  // And then call it
-  SEXP res = Rf_eval(mcall, envir);
-
   UNPROTECT(n_protect);
-  return res;
+  return mcall;
 }

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -137,3 +137,18 @@ test_that("method lookup fails with informative messages", {
   expect_snapshot_error(foo(TRUE, list()))
   expect_snapshot_error(foo(tibble::tibble(), .POSIXct(double())))
 })
+
+
+test_that("method dispatch preserves method return visibility", {
+  foo <- new_generic("foo", "x")
+  method(foo, class_integer) <- function(x) invisible("bar")
+  expect_invisible(foo(1L))
+
+  method(foo, class_character) <- function(x) {
+    if (x == "nope") return(invisible("bar"))
+    "bar"
+  }
+
+  expect_visible(foo("yep"))
+  expect_invisible(foo("nope"))
+})


### PR DESCRIPTION
Closes #196

Methods which return invisibly will now retain their invisible status. 

Perhaps there are better ways to manage this, but I took the simple route and just returned the call to evaluate from the R side. It's a bit roundabout, but provides an easy solution with minimal impact to the rest of the code base.

### Changes:

- C-level `method_call_` now returns the method call `SEXP`, not the return value
- `R7_dispatch` now evaluates the call from the R side to take advantage of R's internal `eval.c` visibility handlers, which I don't think are exposed to the R extension headers.

### Adds:

- Unit tests for visibility of method return