### PR TITLE
Symbol registration cleanup

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -16,15 +16,11 @@ static const R_CallMethodDef CallEntries[] = {
     {NULL, NULL, 0}
 };
 
-SEXP parent_sym;
-SEXP name_sym;
-SEXP ANY_sym;
+SEXP sym_ANY;
 
 void R_init_S7(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
-    parent_sym = Rf_install("parent");
-    name_sym = Rf_install("name");
-    ANY_sym = Rf_install("ANY");
+    sym_ANY = Rf_install("ANY");
 }

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -3,8 +3,7 @@
 #include <Rinternals.h>
 
 extern SEXP parent_sym;
-extern SEXP name_sym;
-extern SEXP ANY_sym;
+extern SEXP sym_ANY;
 
 // Recursively walk through method table to perform iterated dispatch
 SEXP method_rec(SEXP table, SEXP signature, R_xlen_t signature_itr) {
@@ -26,7 +25,7 @@ SEXP method_rec(SEXP table, SEXP signature, R_xlen_t signature_itr) {
   }
 
   // ANY fallback
-  SEXP val = Rf_findVarInFrame(table, ANY_sym);
+  SEXP val = Rf_findVarInFrame(table, sym_ANY);
   if (TYPEOF(val) == ENVSXP) {
     val = method_rec(val, signature, signature_itr + 1);
   }
@@ -45,7 +44,7 @@ void S7_method_lookup_error(SEXP generic, SEXP signature) {
   if (S7_method_lookup_error_fun == NULL) {
     S7_method_lookup_error_fun = Rf_findVarInFrame(ns, Rf_install("method_lookup_error"));
   }
-  SEXP name = Rf_getAttrib(generic, Rf_install("name"));
+  SEXP name = Rf_getAttrib(generic, R_NameSymbol);
   SEXP args = Rf_getAttrib(generic, Rf_install("dispatch_args"));
   SEXP S7_method_lookup_error_call = PROTECT(Rf_lang4(S7_method_lookup_error_fun, name, args, signature));
   Rf_eval(S7_method_lookup_error_call, ns);


### PR DESCRIPTION
* `name_sym` and `parent_sym` aren't used anywhere
* Use `sym` prefix instead of suffix
* Use `R_NameSymbol`