### PR TITLE
Fix the codecov badges on the readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental) [![R-CMD-check](https://github.com/RConsortium/OOP-WG/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RConsortium/OOP-WG/actions/workflows/R-CMD-check.yaml) [![Codecov test coverage](https://app.codecov.io/gh/RConsortium/OOP-WG/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RConsortium/OOP-WG?branch=main)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental) [![R-CMD-check](https://github.com/RConsortium/OOP-WG/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RConsortium/OOP-WG/actions/workflows/R-CMD-check.yaml) [![Codecov test coverage](https://codecov.io/gh/RConsortium/OOP-WG/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RConsortium/OOP-WG?branch=main)
 
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/RConsortium/OOP-WG/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RConsortium/OOP-WG/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://app.codecov.io/gh/RConsortium/OOP-WG/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RConsortium/OOP-WG?branch=main)
+coverage](https://codecov.io/gh/RConsortium/OOP-WG/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RConsortium/OOP-WG?branch=main)
 
 <!-- badges: end -->
 


### PR DESCRIPTION
It seems the badge url should _not_ have an app subdomain, while the link does.