### PR TITLE
Don't embed external generics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # S7 (development version)
 
+* `method<-` now returns an external generic when inside a package and defining
+  a method for a generic not found inside the package. This ensures that your
+  package end up with a copy of a generic from another package inside of it 
+  (#364).
+
 * S7 provides a new automatic backward compatibility mechanism to provide
   a version of `@` that works in R before version 4.3 (#326).
 

--- a/R/method-register.R
+++ b/R/method-register.R
@@ -56,7 +56,6 @@
 #' bizarro(head(mtcars))
 `method<-` <- function(generic, signature, value) {
   register_method(generic, signature, value, env = parent.frame())
-  invisible(generic)
 }
 
 register_method <- function(generic,

--- a/tests/testthat/test-method-register.R
+++ b/tests/testthat/test-method-register.R
@@ -48,7 +48,7 @@ describe("method registration", {
     expect_equal(sum(foo2()), "foo")
 
     # and doesn't modify generic
-    expect_equal(sum, base::sum)
+    expect_equal(sum, new_external_generic("base", "sum", "__S3__"))
   })
 
   it("can register S7 method for S3 Ops generic", {


### PR DESCRIPTION
Fixes #364

To review this, I think you'll need to read `register_method()` and convince yourself that when `generic` isn't a local generic (i.e. from the current package), we'll always return an external generic, which is basically a lazy pointer to the generic.