### PR TITLE
fix: duplicate "error" in S7_error_method_not_found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # S7 (development version)
 
 * Internal changes to support R-devel (4.6) (#592, #593, #598, #600).
+* `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604)
 
 # S7 0.2.1
 

--- a/R/method-dispatch.R
+++ b/R/method-dispatch.R
@@ -2,7 +2,7 @@
 method_lookup_error <- function(name, args) {
   types <- vcapply(args, obj_desc)
   msg <- method_lookup_error_message(name, types)
-  cnd <- errorCondition(msg, class = c("S7_error_method_not_found", "error"))
+  cnd <- errorCondition(msg, class = "S7_error_method_not_found")
   stop(cnd)
 }
 

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -167,8 +167,7 @@ test_that("single dispatch fails with informative messages", {
     fail(Foo(x = 1))
   })
 
-  cnd <- tryCatch(fail(TRUE), S7_error_method_not_found = identity)
-  expect_s3_class(cnd, c("S7_error_method_not_found", "error", "condition"), exact = TRUE)
+  expect_error(fail(TRUE), class = "S7_error_method_not_found")
 })
 
 test_that("multiple dispatch fails with informative messages", {
@@ -184,10 +183,14 @@ test_that("multiple dispatch fails with informative messages", {
     fail(TRUE, TRUE)
   })
 
-  cnd <- tryCatch(fail(TRUE, TRUE), S7_error_method_not_found = identity)
-  expect_s3_class(cnd, c("S7_error_method_not_found", "error", "condition"), exact = TRUE)
+  expect_error(fail(TRUE, TRUE), class = "S7_error_method_not_found")
 })
 
+test_that("S7_error_method_not_found error class is not duplicated", {
+  fail <- new_generic("fail", "x")
+  cnd <- tryCatch(fail(TRUE), S7_error_method_not_found = identity)
+  expect_s3_class(cnd, c("S7_error_method_not_found", "error", "condition"), exact = TRUE)
+})
 
 test_that("method dispatch preserves method return visibility", {
   foo <- new_generic("foo", "x")

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -167,7 +167,8 @@ test_that("single dispatch fails with informative messages", {
     fail(Foo(x = 1))
   })
 
-  expect_error(fail(TRUE), class = "S7_error_method_not_found")
+  cnd <- tryCatch(fail(TRUE), S7_error_method_not_found = identity)
+  expect_s3_class(cnd, c("S7_error_method_not_found", "error", "condition"), exact = TRUE)
 })
 
 test_that("multiple dispatch fails with informative messages", {
@@ -183,7 +184,8 @@ test_that("multiple dispatch fails with informative messages", {
     fail(TRUE, TRUE)
   })
 
-  expect_error(fail(TRUE, TRUE), class = "S7_error_method_not_found")
+  cnd <- tryCatch(fail(TRUE, TRUE), S7_error_method_not_found = identity)
+  expect_s3_class(cnd, c("S7_error_method_not_found", "error", "condition"), exact = TRUE)
 })
 
 


### PR DESCRIPTION
purely cosmetic, but prevents having to `unique` the `class` for logs.

```r
fail <- S7::new_generic("fail", "x")
tryCatch(fail(TRUE), S7_error_method_not_found = \(e) print(class(e)))
[1] "S7_error_method_not_found" "error"                     "error"                     "condition" 
```

unsure if tightening the tests is useful