### PR TITLE
Temporary R 4.6 CRAN check fix (revisited)

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -4,6 +4,7 @@
 // These must be defined before including R headers.
 #define R_NO_REMAP
 #define ENABLE_LEGACY_NONAPI
+#define ENABLE_LEGACY_NONAPI_FUNS
 
 #include <R.h>
 #include <Rinternals.h>


### PR DESCRIPTION
Small followup to #598 using the legacy envvar that landed in R.