### PR TITLE
Wrap property getting and setting errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # S7 (development version)
 
+* Errors raised by `prop()` and `prop<-()` (including from custom getters and setters) now report a synthetic `<Class>@<prop>` call site, making it obvious which property triggered the error (#536).
 * `new_object()` no longer materialises ALTREP parent values (e.g. `seq_len()`), so constructing an S7 object that wraps a large compact integer sequence is now O(1) in memory instead of O(n) (@kschaubroeck, #607).
 * Internal changes to support R-devel (4.6) (#592, #593, #598, #600).
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604)

--- a/R/property.R
+++ b/R/property.R
@@ -194,7 +194,7 @@ prop_default <- function(prop, envir, package) {
 #' lexington@height <- 14
 #' prop(lexington, "height") <- 15
 prop <- function(object, name) {
-  .Call(prop_, object, name)
+  with_prop_call(object, name, .Call(prop_, object, name))
 }
 
 propr <- function(object, name) {
@@ -235,7 +235,32 @@ prop_obj <- function(object, name) {
 #'   [validate()] on the object before returning.
 #' @export
 `prop<-` <- function(object, name, check = TRUE, value) {
-  .Call(prop_set_, object, name, check, value)
+  with_prop_call(
+    object,
+    name,
+    .Call(prop_set_, object, name, check, value)
+  )
+}
+
+# Rewrite the `call` attribute of any error raised by `expr` to a synthetic
+# `<Class>@<prop>` expression so the displayed error points at the property
+# being read or set, instead of dumping the body of a custom getter/setter
+# closure (#536).
+with_prop_call <- function(object, name, expr) {
+  withCallingHandlers(
+    expr,
+    error = function(cnd) {
+      # Only replace if call is null or an inlined function
+      if (!is.null(cnd$call) && !is.function(cnd$call[[1]])) {
+        return()
+      }
+      class_name <- attr(S7_class(object), "name", exact = TRUE) %||% "<S7>"
+      call <- call("@", as.name(class_name), as.name(name))
+
+      cnd$call <- call
+      stop(cnd)
+    }
+  )
 }
 
 `propr<-` <- local({

--- a/tests/testthat/_snaps/property.md
+++ b/tests/testthat/_snaps/property.md
@@ -11,7 +11,7 @@
     Code
       obj@x <- 1
     Condition
-      Error:
+      Error in `foo@x`:
       ! Can't set read-only property <foo>@x
 
 # prop setting / errors if the property doesn't exist or is wrong class
@@ -20,12 +20,12 @@
       obj <- foo(123)
       obj@foo <- 10
     Condition
-      Error:
+      Error in `foo@foo`:
       ! Can't find property <foo>@foo
     Code
       obj@x <- "x"
     Condition
-      Error:
+      Error in `foo@x`:
       ! <foo>@x must be <double>, not <character>
 
 # prop setting / validates all attributes if custom setter
@@ -34,7 +34,7 @@
       obj <- foo(y = 123, x = 123)
       obj@x <- "x"
     Condition
-      Error:
+      Error in `foo@y`:
       ! <foo>@y must be <double>, not <character>
 
 # props<- / `check = FALSE` skip validation
@@ -123,32 +123,32 @@
     Code
       my_obj@null <- "x"
     Condition
-      Error:
+      Error in `my_class@null`:
       ! <my_class>@null must be <NULL>, not <character>
     Code
       my_obj@base <- "x"
     Condition
-      Error:
+      Error in `my_class@base`:
       ! <my_class>@base must be <integer>, not <character>
     Code
       my_obj@S3 <- "x"
     Condition
-      Error:
+      Error in `my_class@S3`:
       ! <my_class>@S3 must be S3<factor>, not <character>
     Code
       my_obj@S4 <- "x"
     Condition
-      Error:
+      Error in `my_class@S4`:
       ! <my_class>@S4 must be S4<class_S4>, not <character>
     Code
       my_obj@S7 <- "x"
     Condition
-      Error:
+      Error in `my_class@S7`:
       ! <my_class>@S7 must be <class_S7>, not <character>
     Code
       my_obj@S7_union <- "x"
     Condition
-      Error:
+      Error in `my_class@S7_union`:
       ! <my_class>@S7_union must be <integer> or <logical>, not <character>
 
 # as_properties() gives useful error messages
@@ -185,7 +185,7 @@
       f <- foo(x = 1L)
       f@x <- 1:2
     Condition
-      Error:
+      Error in `foo@x`:
       ! <foo>@x must be length 1
     Code
       foo(x = 1:2)
@@ -255,4 +255,17 @@
       [tx] finished transmitting.
     Code
       expect_equal(receiver@message, "goodbye")
+
+# sys.call() inside a setter is named after the property (#536)
+
+    Code
+      x@x
+    Condition
+      Error in `foo@x`:
+      ! nope
+    Code
+      x@x <- -1
+    Condition
+      Error in `foo@x`:
+      ! nope
 

--- a/tests/testthat/_snaps/valid.md
+++ b/tests/testthat/_snaps/valid.md
@@ -50,6 +50,6 @@
     Code
       foo(x = 123)
     Condition
-      Error:
+      Error in `foo@x`:
       ! <foo>@x must be <double>, not <character>
 

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -598,3 +598,23 @@ test_that("custom setters don't evaulate call objects", {
     quote(abort(msg = "boom3", foo = bar, baz))
   )
 })
+
+test_that("sys.call() inside a setter is named after the property (#536)", {
+  error <- FALSE
+  foo <- new_class(
+    "foo",
+    properties = list(
+      x = new_property(
+        setter = \(self, value) if (error) stop("nope") else self,
+        getter = \(self) if (error) stop("nope") else 1
+      )
+    )
+  )
+
+  x <- foo()
+  error <- TRUE
+  expect_snapshot(error = TRUE, {
+    x@x
+    x@x <- -1
+  })
+})


### PR DESCRIPTION
This is a significant improvement in messaging, but this implementation might not be worth it because of the performance cost (getting a property currently takes ~2µs on my machine)

```R
x <- new_class("foo")()
f <- function(x) 1

bench::mark(
  f(),
  withCallingHandlers(f()),
  with_prop_call(x, "foo", f())
)[1:4]

#> # A tibble: 3 × 4
#>   expression                             min   median `itr/sec`
#>   <bch:expr>                        <bch:tm> <bch:tm>     <dbl>
#> 1 "f()"                                    0    123ns  8495343.
#> 2 "withCallingHandlers(f())"           328ns    533ns  1803805.
#> 3 "with_prop_call(x, \"foo\", f())"    533ns    697ns  1333597.
```

Nevertheless, it might suggest a faster approach.

Fixes #536