### PR TITLE
Wrap `LANGSXP` and `SYMSXP` when validating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # S7 (development version)
 
 * `new_object()` no longer materialises ALTREP parent values (e.g. `seq_len()`), so constructing an S7 object that wraps a large compact integer sequence is now O(1) in memory instead of O(n) (@kschaubroeck, #607).
+* `prop<-()` (and `@<-`) no longer fails when assigning a call or symbol to a property (#511).
 * Internal changes to support R-devel (4.6) (#592, #593, #598, #600).
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604)
 

--- a/src/prop.c
+++ b/src/prop.c
@@ -250,7 +250,26 @@ void prop_validate(SEXP property, SEXP value, SEXP object) {
   if (prop_validate == NULL)
     prop_validate = ns_get("prop_validate");
 
+  int n_protected = 0;
+
+  // Wrap value and object in quote() if they are calls or symbols, so they
+  // don't get evaluated by Rf_eval()
+  switch (TYPEOF(value)) {
+  case LANGSXP:
+  case SYMSXP:
+    value = PROTECT(Rf_lang2(fn_base_quote, value));
+    ++n_protected;
+  }
+
+  switch (TYPEOF(object)) {
+  case LANGSXP:
+  case SYMSXP:
+    object = PROTECT(Rf_lang2(fn_base_quote, object));
+    ++n_protected;
+  }
+
   SEXP errmsg = eval_here(Rf_lang4(prop_validate, property, value, object));
+  UNPROTECT(n_protected);
   if (errmsg != R_NilValue) signal_error(errmsg);
 }
 

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -598,3 +598,14 @@ test_that("custom setters don't evaulate call objects", {
     quote(abort(msg = "boom3", foo = bar, baz))
   )
 })
+
+test_that("prop<- doesn't evaluate language values (#511)", {
+  Cls <- new_class("Cls", properties = list(r = class_any))
+
+  foo <- Cls()
+  foo@r <- as.symbol("x")
+  expect_equal(foo@r, quote(x))
+
+  foo@r <- quote(x + 1)
+  expect_equal(foo@r, quote(x + 1))
+})


### PR DESCRIPTION
The neighboring `obj_validate` and `do_call2` helpers already wrapped language values in `quote()` to prevent this; `prop_validate` did not.

Fixes #511