### PR TITLE
Unconditionally register a on-load hook

### DIFF
--- a/R/external-generic.R
+++ b/R/external-generic.R
@@ -103,9 +103,8 @@ methods_register <- function() {
 
     if (isNamespaceLoaded(x$generic$package)) {
       register()
-    } else {
-      setHook(packageEvent(x$generic$package, "onLoad"), register)
     }
+    setHook(packageEvent(x$generic$package, "onLoad"), register)
   }
 
   invisible()


### PR DESCRIPTION
This handles the (admittedly rare) case where a user unloads then re-loads a package.

Spotted in #573