### PR TITLE
Use `UnwindProtect` to clean up on getter error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # S7 (development version)
 
 * `new_object()` no longer materialises ALTREP parent values (e.g. `seq_len()`), so constructing an S7 object that wraps a large compact integer sequence is now O(1) in memory instead of O(n) (@kschaubroeck, #607).
+* `prop()` (and `@`) no longer leaves an object in a broken state when a custom getter signals an error (#520).
 * Internal changes to support R-devel (4.6) (#592, #593, #598, #600).
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604)
 

--- a/src/prop.c
+++ b/src/prop.c
@@ -243,6 +243,23 @@ void accessor_no_recurse_clear(SEXP object, SEXP name_sym, SEXP no_recurse_list_
 #define setter_no_recurse_clear(...) \
     accessor_no_recurse_clear(__VA_ARGS__, sym_dot_setting_prop)
 
+typedef struct {
+  SEXP fn;
+  SEXP arg;
+  SEXP object;
+  SEXP name_sym;
+} accessor_call_data;
+
+static SEXP accessor_eval(void* data) {
+  accessor_call_data* d = data;
+  return do_call1(d->fn, d->arg);
+}
+
+static void getter_no_recurse_cleanup(void* data, Rboolean jump) {
+  accessor_call_data* d = data;
+  getter_no_recurse_clear(d->object, d->name_sym);
+}
+
 static inline
 void prop_validate(SEXP property, SEXP value, SEXP object) {
 
@@ -314,10 +331,16 @@ SEXP prop_(SEXP object, SEXP name) {
   if (TYPEOF(getter) == CLOSXP &&
       getter_callable_no_recurse(getter, object, name_sym)) {
 
-    SEXP value = PROTECT(do_call1(getter, object));
-    getter_no_recurse_clear(object, name_sym);
-    UNPROTECT(1); // value
-    return value;
+    // Use R_UnwindProtect so .getting_prop is cleared even if the
+    // getter signals an error (#520).
+    accessor_call_data data = {getter, object, object, name_sym};
+    return R_UnwindProtect(
+      accessor_eval, 
+      &data, 
+      getter_no_recurse_cleanup, 
+      &data, 
+      NULL
+    );
   }
 
   // try to resolve property from the object attributes

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -460,6 +460,42 @@ test_that("custom setters can invoke setters on non-self objects", {
 })
 
 
+test_that("erroring getter/setter doesn't leave object in broken state", {
+  # https://github.com/RConsortium/S7/issues/520
+
+  Test <- new_class(
+    "Test",
+    properties = list(
+      a = new_property(
+        getter = function(self) {
+          if (self@a == 10) {
+            stop("a is 10")
+          }
+          self@a
+        },
+        setter = function(self, value) {
+          if (value == 11) {
+            stop("value is 11")
+          }
+          self@a <- value
+          self
+        }
+      )
+    )
+  )
+
+  t <- Test(a = 10)
+  expect_error(t@a, "a is 10")
+  expect_error(t@a, "a is 10")
+
+  expect_error(t@a <- 11, "value is 11")
+  expect_error(t@a <- 11, "value is 11")
+
+  t@a <- 1
+  expect_equal(t@a, 1)
+})
+
+
 test_that("custom getters don't infinitely recurse", {
   # https://github.com/RConsortium/S7/issues/403
 


### PR DESCRIPTION
I also added a test for an erroring setter, but as claude points out, the setter path doesn't have the same bug because it shallow-duplicates the object before mutating `.setting_prop`, so the mutated copy is discarded on error.

Fixes #520