### PR TITLE
Empower `S7_data()` for S3 objects then use it in `str()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 * `new_object()` no longer materialises ALTREP parent values (e.g. `seq_len()`), so constructing an S7 object that wraps a large compact integer sequence is now O(1) in memory instead of O(n) (@kschaubroeck, #607).
 * Internal changes to support R-devel (4.6) (#592, #593, #598, #600).
+* `S7_data()` now preserves the S3 class when the S7 class inherits from an S3 class, so e.g. `S7_data()` on a data.frame subclass now returns a data.frame (#380).
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604)
+* `str()` on S7 objects that inherit from data.frame (or other S3 classes whose underlying data has a `dim` attribute incompatible with the bare base type) no longer errors (#494).
 
 # S7 0.2.2
 

--- a/R/class.R
+++ b/R/class.R
@@ -322,15 +322,7 @@ str.S7_object <- function(object, ..., nest.lev = 0) {
       cat(" ")
     }
 
-    attrs <- attributes(object)
-    if (is.environment(object)) {
-      attributes(object) <- NULL
-    } else {
-      attributes(object) <- list(names = names(object), dim = dim(object))
-    }
-
-    str(object, nest.lev = nest.lev)
-    attributes(object) <- attrs
+    str(S7_data(object), nest.lev = nest.lev)
   } else {
     cat("\n")
   }

--- a/R/data.R
+++ b/R/data.R
@@ -1,8 +1,10 @@
 #' Get/set underlying "base" data
 #'
 #' When an S7 class inherits from an existing base type, it can be useful
-#' to work with the underlying object, i.e. the S7 object stripped of class
-#' and properties.
+#' to work with the underlying object, i.e. the S7 object stripped of its
+#' S7 class and properties. If the class inherits from an S3 class,
+#' `S7_data()` preserves the S3 class so the result remains a valid
+#' object of that type.
 #'
 #' @inheritParams prop
 #' @param value Object used to replace the underlying data.
@@ -18,10 +20,28 @@
 #'
 #' S7_data(y) <- c("a", "b")
 #' y
+#'
+#' # S3 classes are preserved
+#' MyDF <- new_class("MyDF", parent = class_data.frame)
+#' S7_data(MyDF(data.frame(x = 1, y = 2)))
 S7_data <- function(object) {
   check_is_S7(object)
 
-  zap_attr(object, c(prop_names(object), "class", "S7_class"))
+  out <- zap_attr(object, c(prop_names(object), "class", "S7_class"))
+
+  base <- base_parent(S7_class(object))
+  if (is_S3_class(base)) {
+    class(out) <- base$class
+  }
+  out
+}
+
+# Walk up the @parent chain to the first non-S7 ancestor (or S7_object).
+base_parent <- function(class) {
+  while (is_class(class) && class@name != "S7_object") {
+    class <- class@parent
+  }
+  class
 }
 
 #' @export

--- a/man/S7_data.Rd
+++ b/man/S7_data.Rd
@@ -24,8 +24,10 @@ invisibly.
 }
 \description{
 When an S7 class inherits from an existing base type, it can be useful
-to work with the underlying object, i.e. the S7 object stripped of class
-and properties.
+to work with the underlying object, i.e. the S7 object stripped of its
+S7 class and properties. If the class inherits from an S3 class,
+\code{S7_data()} preserves the S3 class so the result remains a valid
+object of that type.
 }
 \examples{
 Text <- new_class("Text", parent = class_character)
@@ -35,4 +37,8 @@ S7_data(y)
 
 S7_data(y) <- c("a", "b")
 y
+
+# S3 classes are preserved
+MyDF <- new_class("MyDF", parent = class_data.frame)
+S7_data(MyDF(data.frame(x = 1, y = 2)))
 }

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -202,6 +202,16 @@
       List of 1
        $ : <text> chr "x"
 
+# S7 object / displays data.frame subclasses without error (#494)
+
+    Code
+      str(mydf(data.frame(a = 1:2, b = 1:2)))
+    Output
+      Classes 'mydf', 'S7_object' and 'data.frame':	2 obs. of  2 variables:
+      <mydf> 'data.frame':	2 obs. of  2 variables:
+       $ a: int  1 2
+       $ b: int  1 2
+
 # S7 object / displays list objects nicely
 
     Code

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -169,6 +169,11 @@ describe("S7 object", {
     })
   })
 
+  it("displays data.frame subclasses without error (#494)", {
+    mydf <- new_class("mydf", class_data.frame, package = NULL)
+    expect_snapshot(str(mydf(data.frame(a = 1:2, b = 1:2))))
+  })
+
   it("displays list objects nicely", {
     foo1 <- new_class(
       "foo1",

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -23,4 +23,19 @@ describe("S7_data", {
     S7_data(x) <- "bar"
     expect_equal(S7_data(x), "bar")
   })
+  it("preserves S3 class from parent (#380)", {
+    mydf <- new_class("mydf", class_data.frame)
+    df <- data.frame(x = 1, y = 2)
+    expect_equal(S7_data(mydf(df)), df)
+  })
+  it("preserves S3 class from grandparent", {
+    mydf <- new_class("mydf", class_data.frame)
+    mydf2 <- new_class("mydf2", mydf)
+    df <- data.frame(x = 1, y = 2)
+    expect_equal(S7_data(mydf2(df)), df)
+  })
+  it("does not add class when parent is a base type", {
+    mychar <- new_class("mychar", class_character)
+    expect_null(attr(S7_data(mychar("x")), "class", exact = TRUE))
+  })
 })


### PR DESCRIPTION
I've implemented these together because (a) they are simple but, more importantly, (b) the fix in `str()` directly inspires the new behaviour in `S7_data()`.

Fixes #380. Fixes #494.