### PR TITLE
Document how to maintain S3 method dispatch for S7 generics

### DIFF
--- a/vignettes/compatibility.Rmd
+++ b/vignettes/compatibility.Rmd
@@ -49,14 +49,36 @@ All up, this means most usage of S7 with S3 will just work.
 You can also register a method for an S7 class and S3 generic without using S7, because all S7 objects have S3 classes, and S3 dispatch will operate on them normally.
 
 ```{r}
-Foo <- new_class("Foo")
+Foo <- new_class("Foo", package = "Bar")
 class(Foo())
 
-mean.Foo <- function(x, ...) {
+`mean.Bar::Foo` <- function(x, ...) {
   "mean of foo"
 }
 
 mean(Foo())
+```
+
+Note that when defining classes in a package, the S3 class name will be `{package}::{class}`, and that means you'll need to use `` ` `` to define S3 methods.
+
+### Generics
+
+If you convert an S3 generic to an S7 generic and want existing S3 methods (typically in other packages) to continue to work, add a `class_any` method that calls `UseMethod()`:
+
+```{r}
+foo <- new_generic("foo", "x")
+
+# Default method dispatches to S3
+method(foo, class_any) <- function(x, ...) {
+  UseMethod("foo")
+}
+```
+
+And then if you need a genuine default method, use S3:
+
+```{r}
+# Define the "true" default method
+foo.default <- function(x) paste0(x, " + 10")
 ```
 
 ### Classes


### PR DESCRIPTION
While I was here I also noticed this was a good place to mention that S3 class names will usually contain `::`.

Fixes #543