### PR TITLE
docs: fix some typos and trim whitespace

### DIFF
--- a/tests/testthat/_snaps/property.md
+++ b/tests/testthat/_snaps/property.md
@@ -97,7 +97,7 @@
     Code
       print(x)
     Output
-      <S7_property> 
+      <S7_property>
        $ name     : chr "foo"
        $ class    : <S7_base_class>: <integer>
        $ getter   : NULL
@@ -108,7 +108,7 @@
       str(list(x))
     Output
       List of 1
-       $ : <S7_property> 
+       $ : <S7_property>
         ..$ name     : chr "foo"
         ..$ class    : <S7_base_class>: <integer>
         ..$ getter   : NULL
@@ -126,12 +126,12 @@
       @ constructor: function(anything, null, base, S3, S4, S7, S7_union) {...}
       @ validator  : <NULL>
       @ properties :
-       $ anything: <ANY>                 
-       $ null    : <NULL>                
-       $ base    : <integer>             
-       $ S3      : S3<factor>            
-       $ S4      : S4<class_S4>          
-       $ S7      : <class_S7>            
+       $ anything: <ANY>
+       $ null    : <NULL>
+       $ base    : <integer>
+       $ S3      : S3<factor>
+       $ S4      : S4<class_S4>
+       $ S7      : <class_S7>
        $ S7_union: <integer> or <logical>
 
 ---
@@ -215,30 +215,30 @@
       ! <foo> object properties are invalid:
       - @x must be length 1
 
-# prop<- won't infinitly recurse on a custom setter
+# prop<- won't infinitely recurse on a custom setter
 
     Code
       obj <- foo()
     Output
-      Starting syncup with value: 
+      Starting syncup with value:
       setting @a <- "a_"
       setting @b <- "b_"
-      Starting syncup with value: b_ 
+      Starting syncup with value: b_
       setting @a <- "a_b_"
       setting @b <- "b_b_"
-      Starting syncup with value: 
+      Starting syncup with value:
       setting @a <- "a_"
-      Starting syncup with value: a_ 
+      Starting syncup with value: a_
       setting @a <- "a_a_"
       setting @b <- "b_a_"
       setting @b <- "b_"
     Code
       obj@a <- "val"
     Output
-      Starting syncup with value: val 
+      Starting syncup with value: val
       setting @a <- "a_val"
       setting @b <- "b_val"
-      Starting syncup with value: b_val 
+      Starting syncup with value: b_val
       setting @a <- "a_b_val"
       setting @b <- "b_b_val"
 
@@ -247,21 +247,21 @@
     Code
       receiver <- Receiver()
     Output
-      [rx] receiving:  
+      [rx] receiving:
       [rx] finished receiving.
     Code
       transmitter <- Transmitter()
     Output
-      [tx] sending:  
-      [rx] receiving:  
+      [tx] sending:
+      [rx] receiving:
       [rx] finished receiving.
       [tx] saving last sent message.
       [tx] finished transmitting.
     Code
       transmitter@message <- "hello"
     Output
-      [tx] sending:  hello 
-      [rx] receiving:  hello 
+      [tx] sending:  hello
+      [rx] receiving:  hello
       [rx] finished receiving.
       [tx] saving last sent message.
       [tx] finished transmitting.
@@ -269,8 +269,8 @@
       expect_equal(receiver@message, "hello")
       transmitter@message <- "goodbye"
     Output
-      [tx] sending:  goodbye 
-      [rx] receiving:  goodbye 
+      [tx] sending:  goodbye
+      [rx] receiving:  goodbye
       [rx] finished receiving.
       [tx] saving last sent message.
       [tx] finished transmitting.

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -12,7 +12,7 @@ describe("property retrieval", {
     expect_snapshot_error(prop(obj, "x"))
     expect_snapshot_error(obj@x)
   })
-  it("evalutes dynamic properties", {
+  it("evaluates dynamic properties", {
     foo <- new_class(
       "foo",
       properties = list(
@@ -444,7 +444,7 @@ test_that("can validate with custom validator", {
   })
 })
 
-test_that("prop<- won't infinitly recurse on a custom setter", {
+test_that("prop<- won't infinitely recurse on a custom setter", {
   chattily_sync_ab <- function(self, value) {
     cat("Starting syncup with value:", value, "\n")
     a_value <- paste0("a_", value)
@@ -569,7 +569,7 @@ test_that("custom setters can call custom getters", {
 })
 
 
-test_that("custom getters don't evaulate call objects", {
+test_that("custom getters don't evaluate call objects", {
   QuotedCall := new_class(
     class_call,
     properties = list(
@@ -593,7 +593,7 @@ test_that("custom getters don't evaulate call objects", {
 })
 
 
-test_that("custom setters don't evaulate call objects", {
+test_that("custom setters don't evaluate call objects", {
   Call := new_class(
     class_call,
     properties = list(


### PR DESCRIPTION
docs: fix some typos and trim whitespace