### PR TITLE
fixes for S4 generics and classes defined across packages

### DIFF
--- a/R/S4.R
+++ b/R/S4.R
@@ -150,7 +150,7 @@ S4_class_name <- function(x) {
 }
 
 S4_package_name <- function(f, env) {
-  if (methods::getPackageName(topenv(env)) == f@package) {
+  if (methods::getPackageName(topenv(env), create = FALSE) == f@package) {
     ## current ns might not be loaded yet, catch here
     return(f@package)
   }

--- a/R/S4.R
+++ b/R/S4.R
@@ -149,6 +149,46 @@ S4_class_name <- function(x) {
   }
 }
 
+S4_package_name <- function(f, env) {
+  if (methods::getPackageName(topenv(env)) == f@package) {
+    ## current ns might not be loaded yet, catch here
+    return(f@package)
+  }
+
+  name <- as.vector(f@generic)
+  generic_in_its_package <- methods::isGeneric(
+    name,
+    where = asNamespace(f@package)
+  )
+  if (generic_in_its_package) {
+    return(f@package)
+  }
+
+  # generic was defined for a function from a different package, like base
+  find_package_with_symbol(name, env, exclude = f@package) %||%
+    stop(
+      "Failed to find originating package for S4 generic '",
+      name,
+      "' in namespace imports.",
+      call. = FALSE
+    )
+}
+
+find_package_with_symbol <- function(name, env, exclude = NULL) {
+  imports <- getNamespaceImports(topenv(env))
+  pkgs <- setdiff(names(imports), exclude)
+  Find(
+    function(pkg) {
+      if (isTRUE(imports[[pkg]])) {
+        name %in% getNamespaceExports(pkg)
+      } else {
+        name %in% imports[[pkg]]
+      }
+    },
+    pkgs
+  )
+}
+
 S4_remove_classes <- function(classes, where = parent.frame()) {
   for (class in classes) {
     suppressWarnings(methods::removeClass(class, topenv(where)))

--- a/R/S4.R
+++ b/R/S4.R
@@ -165,17 +165,10 @@ S4_package_name <- function(f, env) {
   }
 
   # generic was defined for a function from a different package, like base
-  find_package_with_symbol(name, env, exclude = f@package) %||%
-    stop2(
-      sprintf(
-        "Failed to find originating package for S4 generic '%s' in imports.",
-        f@package
-      ),
-      call = NULL
-    )
+  find_package_with_symbol(name, env, f@generic, exclude = f@package)
 }
 
-find_package_with_symbol <- function(name, env, exclude = NULL) {
+find_package_with_symbol <- function(name, env, generic, exclude = NULL) {
   imports <- getNamespaceImports(topenv(env))
   pkgs <- setdiff(names(imports), exclude)
   for (pkg in pkgs) {
@@ -186,6 +179,14 @@ find_package_with_symbol <- function(name, env, exclude = NULL) {
       return(pkg)
     }
   }
+
+  stop2(
+    sprintf(
+      "Failed to find originating package for S4 generic '%s' in imports.",
+      generic
+    ),
+    call = NULL
+  )
 }
 
 S4_remove_classes <- function(classes, where = parent.frame()) {

--- a/R/S4.R
+++ b/R/S4.R
@@ -167,9 +167,9 @@ S4_package_name <- function(f, env) {
   # generic was defined for a function from a different package, like base
   find_package_with_symbol(name, env, exclude = f@package) %||%
     stop(
-      "Failed to find originating package for S4 generic '",
-      name,
-      "' in namespace imports.",
+      sprintf(
+        "Failed to find originating package for S4 generic '%s' in imports."
+      ),
       call. = FALSE
     )
 }

--- a/R/S4.R
+++ b/R/S4.R
@@ -165,10 +165,17 @@ S4_package_name <- function(f, env) {
   }
 
   # generic was defined for a function from a different package, like base
-  find_package_with_symbol(name, env, f@generic, exclude = f@package)
+  find_package_with_symbol(name, env, exclude = f@package) %||%
+    stop2(
+      sprintf(
+        "Failed to find originating package for S4 generic '%s' in imports.",
+        f@generic
+      ),
+      call = NULL
+    )
 }
 
-find_package_with_symbol <- function(name, env, generic, exclude = NULL) {
+find_package_with_symbol <- function(name, env, exclude = NULL) {
   imports <- getNamespaceImports(topenv(env))
   pkgs <- setdiff(names(imports), exclude)
   for (pkg in pkgs) {
@@ -179,14 +186,6 @@ find_package_with_symbol <- function(name, env, generic, exclude = NULL) {
       return(pkg)
     }
   }
-
-  stop2(
-    sprintf(
-      "Failed to find originating package for S4 generic '%s' in imports.",
-      generic
-    ),
-    call = NULL
-  )
 }
 
 S4_remove_classes <- function(classes, where = parent.frame()) {

--- a/R/S4.R
+++ b/R/S4.R
@@ -166,11 +166,12 @@ S4_package_name <- function(f, env) {
 
   # generic was defined for a function from a different package, like base
   find_package_with_symbol(name, env, exclude = f@package) %||%
-    stop(
+    stop2(
       sprintf(
-        "Failed to find originating package for S4 generic '%s' in imports."
+        "Failed to find originating package for S4 generic '%s' in imports.",
+        f@package
       ),
-      call. = FALSE
+      call = NULL
     )
 }
 

--- a/R/S4.R
+++ b/R/S4.R
@@ -177,16 +177,14 @@ S4_package_name <- function(f, env) {
 find_package_with_symbol <- function(name, env, exclude = NULL) {
   imports <- getNamespaceImports(topenv(env))
   pkgs <- setdiff(names(imports), exclude)
-  Find(
-    function(pkg) {
-      if (isTRUE(imports[[pkg]])) {
-        name %in% getNamespaceExports(pkg)
-      } else {
+  for (pkg in pkgs) {
+    if (
+      (isTRUE(imports[[pkg]]) && name %in% getNamespaceExports(pkg)) ||
         name %in% imports[[pkg]]
-      }
-    },
-    pkgs
-  )
+    ) {
+      return(pkg)
+    }
+  }
 }
 
 S4_remove_classes <- function(classes, where = parent.frame()) {

--- a/R/S4.R
+++ b/R/S4.R
@@ -155,7 +155,7 @@ S4_package_name <- function(f, env) {
     return(f@package)
   }
 
-  name <- as.vector(f@generic)
+  name <- as.character(f@generic)
   generic_in_its_package <- methods::isGeneric(
     name,
     where = asNamespace(f@package)

--- a/R/external-generic.R
+++ b/R/external-generic.R
@@ -40,7 +40,7 @@ new_external_generic <- function(package, name, dispatch_args, version = NULL) {
   out
 }
 
-as_external_generic <- function(x) {
+as_external_generic <- function(x, env = parent.frame()) {
   if (is_S7_generic(x)) {
     pkg <- package_name(x)
     new_external_generic(pkg, x@name, x@dispatch_args)
@@ -50,7 +50,8 @@ as_external_generic <- function(x) {
     pkg <- package_name(x$generic)
     new_external_generic(pkg, x$name, "__S3__")
   } else if (is_S4_generic(x)) {
-    new_external_generic(x@package, as.vector(x@generic), x@signature)
+    pkg <- S4_package_name(x, env)
+    new_external_generic(pkg, as.vector(x@generic), x@signature)
   }
 }
 

--- a/R/method-register-S4.R
+++ b/R/method-register-S4.R
@@ -18,8 +18,8 @@ S4_class <- function(x, S4_env, call = sys.call(-1L)) {
     any = "ANY",
     S7_base = base_to_S4(x$class),
     S4 = x,
-    S7 = S4_registered_class(x, call = call),
-    S7_S3 = S4_registered_class(x, call = call),
+    S7 = S4_registered_class(x, S4_env = S4_env, call = call),
+    S7_S3 = S4_registered_class(x, S4_env = S4_env, call = call),
     S7_union = stop2(
       "Internal error: union should be flattened upstream.",
       call = NULL
@@ -36,9 +36,13 @@ base_to_S4 <- function(class) {
   switch(class, double = "numeric", class)
 }
 
-S4_registered_class <- function(x, call = sys.call(-1L)) {
+S4_registered_class <- function(
+  x,
+  S4_env,
+  call = sys.call(-1L)
+) {
   class <- tryCatch(
-    methods::getClass(class_register(x)),
+    methods::getClass(class_register(x), where = S4_env),
     error = function(err) NULL
   )
   if (is.null(class)) {

--- a/R/method-register.R
+++ b/R/method-register.R
@@ -99,7 +99,7 @@ register_method <- function(
   # if we're inside a package, we also need to be able register methods
   # when the package is loaded
   if (!is.null(package) && !is_local_generic(generic, package)) {
-    generic <- as_external_generic(generic)
+    generic <- as_external_generic(generic, env)
     external_methods_add(package, generic, signature, method)
   }
 

--- a/tests/testthat/_snaps/S4.md
+++ b/tests/testthat/_snaps/S4.md
@@ -25,5 +25,5 @@
       S4_package_name(mock_S4, stats_ns)
     Condition
       Error:
-      ! Failed to find originating package for S4 generic 'base' in imports.
+      ! Failed to find originating package for S4 generic 'nonexistent_generic' in imports.
 

--- a/tests/testthat/_snaps/S4.md
+++ b/tests/testthat/_snaps/S4.md
@@ -19,3 +19,11 @@
       Error:
       ! Unsupported S4 object: must be a class generator or a class definition, not a <double>.
 
+# S4_package_name errors if originating package can't be found
+
+    Code
+      S4_package_name(mock_S4, stats_ns)
+    Condition
+      Error:
+      ! Failed to find originating package for S4 generic 'base' in imports.
+

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -180,3 +180,15 @@ test_that("S4_package_name resolves S4 package name correctly in all cases", {
   mock_S4@package <- "base"
   expect_equal(S4_package_name(mock_S4, stats_ns), "graphics")
 })
+
+test_that("S4_package_name errors if originating package can't be found", {
+  stats_ns <- asNamespace("stats")
+
+  methods::setGeneric("nonexistent_generic", function(x) {
+    standardGeneric("nonexistent_generic")
+  })
+  on.exit(methods::removeGeneric("nonexistent_generic"))
+  mock_S4 <- getGeneric("nonexistent_generic")
+  mock_S4@package <- "base"
+  expect_snapshot(S4_package_name(mock_S4, stats_ns), error = TRUE)
+})

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -160,3 +160,23 @@ describe("S4_class_dispatch", {
     expect_equal(S4_class_dispatch("Foo1"), "S4/mypkg::Foo1")
   })
 })
+
+test_that("S4_package_name resolves S4 package name correctly in all cases", {
+  stats_ns <- asNamespace("stats")
+
+  # Case 1: Generic in declared package
+  show_S4 <- getGeneric("show")
+  expect_equal(S4_package_name(show_S4, stats_ns), "methods")
+
+  # Case 2: Current package bypass
+  dummy_S4 <- getGeneric("show")
+  dummy_S4@package <- "stats"
+  expect_equal(S4_package_name(dummy_S4, stats_ns), "stats")
+
+  # Case 3: Originating package in namespace imports
+  methods::setGeneric("axTicks")
+  on.exit(methods::removeGeneric("axTicks"))
+  mock_S4 <- getGeneric("axTicks")
+  mock_S4@package <- "base"
+  expect_equal(S4_package_name(mock_S4, stats_ns), "graphics")
+})


### PR DESCRIPTION
This contains two fixes:
1. The current code assumes that `generic@package` indicates the home package of the generic. Unfortunately, that is not the case in general. The methods package uses `@package` to refer to the package defining the original function that the generic represents. Thus, `setGeneric("nrow", ...)` in a package will create a generic where `@package == "base"`. To make matters worse, `topenv(environment(generic))` is the namespace of `@package`, so the only way to find the package defining the generic is a brute force search through namespace imports.
2. Much easier, I noticed that the S4 method registration path was not passing along the calling environment to the `getClass()` call to resolve S7 old classes, even though that seemed to be the intent. Omitting `where` might problem if a parent package registers those classes with S4.