### PR TITLE
S7_class becomes a reserved attribute

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -436,4 +436,14 @@ check_prop_names <- function(properties, call = sys.call(-1L)) {
     )
     stop2(msg, call = call)
   }
+
+  reserved <- intersect("S7_class", names(properties))
+  if (length(reserved)) {
+    msg <- paste0(
+      "Property can't use S7 reserved name: ",
+      paste0(reserved, collapse = ", "),
+      "."
+    )
+    stop2(msg, call = call)
+  }
 }

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -283,6 +283,11 @@
       Error in `new_class()`:
       ! Property can't be named: names.
     Code
+      new_class("foo", properties = list(S7_class = class_any))
+    Condition
+      Error in `new_class()`:
+      ! Property can't use S7 reserved name: S7_class.
+    Code
       new_class("foo", properties = list(dim = NULL | class_integer))
     Condition
       Error in `new_class()`:

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -323,6 +323,7 @@ test_that("can round trip to disk and back", {
 test_that("can't create class with reserved property names", {
   expect_snapshot(error = TRUE, {
     new_class("foo", properties = list(names = class_character))
+    new_class("foo", properties = list(S7_class = class_any))
     new_class("foo", properties = list(dim = NULL | class_integer))
     new_class(
       "foo",


### PR DESCRIPTION
This is hopefully an obvious change where the `S7_class` attribute is no longer allowed to be declared as a property. Just noticed this while I was working on the S4 support.