### PR TITLE
Clear error when `S7_dispatch()` called outside a generic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 * `prop()` no longer leaves an object in a broken state when a custom getter signals an error (#520, #640, #638).
 * `prop<-()` no longer fails when assigning a call or symbol to a property (#511, #633, #638).
 * New `prop_info()` returns a data frame summarising the properties of an S7 object or class, with one row per property and columns for name, default, class, getter, setter, and validator (#551).
+* `S7_dispatch()` now gives a clear error when called from a function that is not an S7 generic, e.g. `unclass(generic)()`, instead of failing with a confusing message (#684).
 * `S7_class()` now returns a class specification for any R object, not just S7 objects. It returns the matching `class_*` for base types, a `new_S3_class()` wrapper for S3 objects, and the S4 class for S4 objects, so the result can be passed directly to `method()` or other S7 dispatch helpers (#559).
 * `S7_class_desc()` is a new exported helper that formats a class specification as a short human-readable string (#594).
 * `S7_data()` now preserves the S3 class when the S7 class inherits from an S3 class, so e.g. `S7_data()` on a data.frame subclass now returns a data.frame (#380).

--- a/R/method-dispatch.R
+++ b/R/method-dispatch.R
@@ -1,4 +1,12 @@
 # Called from C
+dispatch_not_generic_error <- function() {
+  stop2(
+    "Must be called from within an S7 generic.",
+    call = quote(S7_dispatch())
+  )
+}
+
+# Called from C
 method_lookup_error <- function(name, args) {
   types <- vcapply(args, obj_desc)
   msg <- method_lookup_error_message(name, types)

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -164,6 +164,12 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
   SEXP generic = CAR(args_); args_ = CDR(args_);
   SEXP envir = CAR(args_); args_ = CDR(args_);
 
+  if (!Rf_inherits(generic, "S7_generic")) {
+    SEXP err_call = PROTECT(Rf_lang1(Rf_install("dispatch_not_generic_error")));
+    Rf_eval(err_call, ns_S7);
+    UNPROTECT(1); // never reached
+  }
+
   // Get the number of arguments to the generic
   SEXP formals = getClosureFormals(generic);
   R_xlen_t n_args = Rf_xlength(formals);

--- a/tests/testthat/_snaps/method-dispatch.md
+++ b/tests/testthat/_snaps/method-dispatch.md
@@ -49,6 +49,14 @@
       - x: <logical>
       - y: <logical>
 
+# dispatch fails cleanly when generic is not an S7 generic
+
+    Code
+      f()
+    Condition
+      Error in `S7_dispatch()`:
+      ! Must be called from within an S7 generic.
+
 # errors from dispatched methods have reasonable tracebacks
 
     Code

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -188,6 +188,11 @@ test_that("multiple dispatch fails with informative messages", {
   expect_error(fail(TRUE, TRUE), class = "S7_error_method_not_found")
 })
 
+test_that("dispatch fails cleanly when generic is not an S7 generic", {
+  f <- function() S7_dispatch()
+  expect_snapshot(f(), error = TRUE)
+})
+
 test_that("S7_error_method_not_found error class is not duplicated", {
   fail <- new_generic("fail", "x")
   cnd <- tryCatch(fail(TRUE), S7_error_method_not_found = identity)


### PR DESCRIPTION
Fixes #684