### PR TITLE
Improve handling of abstract S3 classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * `class_POSIXct` uses the `tzone` attribute (not `tz`), and allows it to be absent (#401).
 * Base type wrappers like `class_integer` now define their constructor and validator in the S7 namespace. (#553).
 * Method dispatch on `class_missing` now correctly handles missing arguments forwarded through a wrapper functions (#595).
-* `convert()` now errors when upcasting to an abstract class, rather than producing an instance of that abstract class (#680).
+* `convert()` now errors when upcasting to an abstract class, rather than producing an instance of that abstract class (#680, #686).
 * `convert()` no longer automatically converts between sibling classes (classes that merely share a common ancestor); the default downcast now applies only when `to` is genuinely a descendant of `from`'s class (#509).
 * `convert()` now falls back to the corresponding `as.*()` function (e.g. `as.character()`) when converting to a base type like `class_character` and no method or inheritance-based default applies, so `convert(1, class_character)` works out of the box (#472).
 * `convert()` no longer errors when `from` is a base or S3 object and `to` is an S7 class that inherits from `from`'s class. The base/S3 value is now passed as `.data` to the `to` constructor (#537).

--- a/R/S3.R
+++ b/R/S3.R
@@ -93,8 +93,10 @@ new_S3_class <- function(class, constructor = NULL, validator = NULL) {
     stop2("`class` must be a character vector.")
   }
   if (!is.null(constructor)) {
+    abstract <- FALSE
     check_S3_constructor(constructor)
   } else {
+    abstract <- TRUE
     constructor <- function(.data) {
       stop2(
         sprintf("S3 class <%s> doesn't have a constructor.", class[[1]]),
@@ -106,7 +108,8 @@ new_S3_class <- function(class, constructor = NULL, validator = NULL) {
   out <- list(
     class = class,
     constructor = constructor,
-    validator = validator
+    validator = validator,
+    abstract = abstract
   )
   class(out) <- "S7_S3_class"
   out

--- a/R/S3.R
+++ b/R/S3.R
@@ -147,6 +147,21 @@ is_S3_class <- function(x) {
   inherits(x, "S7_S3_class")
 }
 
+# Detect the stub constructor that `new_S3_class()` inserts when no constructor
+# is supplied. Needed as a fallback for `S7_S3_class` objects created by older
+# versions of S7.
+is_S3_stub_constructor <- function(constructor) {
+  if (!is.function(constructor)) {
+    return(FALSE)
+  }
+  call <- find_call(body(constructor), quote(sprintf))
+  if (is.null(call)) {
+    return(FALSE)
+  }
+  fmt <- call[[2]]
+  is.character(fmt) && grepl("doesn't have a constructor", fmt, fixed = TRUE)
+}
+
 # -------------------------------------------------------------------------
 # Pull out validation functions so hit by code coverage
 

--- a/R/class.R
+++ b/R/class.R
@@ -267,6 +267,13 @@ check_can_inherit <- function(
 
 is_class <- function(x) inherits(x, "S7_class")
 
+# A class you can't supply an instance of: an abstract S7 class, or an S3 class
+# registered without a constructor (e.g. a marker class like "gg" or "POSIXt").
+class_is_abstract <- function(class) {
+  (is_class(class) && class@abstract) ||
+    (is_S3_class(class) && class$abstract)
+}
+
 check_parent <- function(parent, class, call = sys.call(-1L)) {
   parent_class <- class@parent
   if (is.null(parent_class)) {
@@ -277,7 +284,7 @@ check_parent <- function(parent, class, call = sys.call(-1L)) {
   }
 
   # Ignore abstract classes since you can't supply an instance
-  if (is_class(parent_class) && parent_class@abstract) {
+  if (class_is_abstract(parent_class)) {
     return()
   }
 

--- a/R/class.R
+++ b/R/class.R
@@ -270,8 +270,13 @@ is_class <- function(x) inherits(x, "S7_class")
 # A class you can't supply an instance of: an abstract S7 class, or an S3 class
 # registered without a constructor (e.g. a marker class like "gg" or "POSIXt").
 class_is_abstract <- function(class) {
-  (is_class(class) && class@abstract) ||
-    (is_S3_class(class) && isTRUE(class$abstract))
+  if (is_class(class)) {
+    class@abstract
+  } else if (is_S3_class(class)) {
+    class$abstract %||% is_S3_stub_constructor(class$constructor)
+  } else {
+    FALSE
+  }
 }
 
 check_parent <- function(parent, class, call = sys.call(-1L)) {

--- a/R/class.R
+++ b/R/class.R
@@ -271,7 +271,7 @@ is_class <- function(x) inherits(x, "S7_class")
 # registered without a constructor (e.g. a marker class like "gg" or "POSIXt").
 class_is_abstract <- function(class) {
   (is_class(class) && class@abstract) ||
-    (is_S3_class(class) && class$abstract)
+    (is_S3_class(class) && isTRUE(class$abstract))
 }
 
 check_parent <- function(parent, class, call = sys.call(-1L)) {

--- a/R/convert.R
+++ b/R/convert.R
@@ -169,7 +169,7 @@ convert_up <- function(from, to, call = sys.call(-1L)) {
   if (is_base_class(to)) {
     from <- zap_attr(from, c(from_props, "S7_class", "class"))
   } else if (is_S3_class(to)) {
-    if (to$abstract) {
+    if (class_is_abstract(to)) {
       msg <- sprintf("Can't convert to abstract class <%s>.", to$class[[1]])
       stop2(msg, call = call)
     }

--- a/R/convert.R
+++ b/R/convert.R
@@ -169,6 +169,10 @@ convert_up <- function(from, to, call = sys.call(-1L)) {
   if (is_base_class(to)) {
     from <- zap_attr(from, c(from_props, "S7_class", "class"))
   } else if (is_S3_class(to)) {
+    if (to$abstract) {
+      msg <- sprintf("Can't convert to abstract class <%s>.", to$class[[1]])
+      stop2(msg, call = call)
+    }
     from <- zap_attr(from, c(from_props, "S7_class"))
     class(from) <- to$class
   } else if (is_class(to)) {

--- a/tests/testthat/_snaps/convert.md
+++ b/tests/testthat/_snaps/convert.md
@@ -14,3 +14,10 @@
       Error in `convert()`:
       ! Can't convert to abstract class <Foo>.
 
+# convert() errors when upcasting to an abstract S3 class (#686)
+
+    Code
+      convert(.POSIXct(1), class_POSIXt)
+    Condition
+      Error in `convert()`:
+      ! Can't convert to abstract class <POSIXt>.

--- a/tests/testthat/_snaps/convert.md
+++ b/tests/testthat/_snaps/convert.md
@@ -21,3 +21,4 @@
     Condition
       Error in `convert()`:
       ! Can't convert to abstract class <POSIXt>.
+

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -167,6 +167,13 @@ describe("new_object()", {
     expect_no_error(Concrete(list(1, "A")))
   })
 
+  it("has fallback for S3 classes created by older S7 (#686)", {
+    old_s3 <- class_POSIXt
+    old_s3$abstract <- NULL
+    Foo <- new_class("Foo", parent = old_s3, constructor = \(x) new_object(x))
+    expect_no_error(Foo(list(1, "A")))
+  })
+
   it("errors if `.parent` is supplied but class has no parent", {
     NoParent <- new_class(
       "NoParent",

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -158,6 +158,15 @@ describe("new_object()", {
     expect_no_error(Concrete(x = 1L))
   })
 
+  it("allows arbitrary placeholder for abstract S3 parents (#686)", {
+    Concrete <- new_class(
+      "Concrete",
+      parent = class_POSIXt,
+      constructor = function(x) new_object(x)
+    )
+    expect_no_error(Concrete(list(1, "A")))
+  })
+
   it("errors if `.parent` is supplied but class has no parent", {
     NoParent <- new_class(
       "NoParent",

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -207,6 +207,12 @@ test_that("convert() errors when upcasting to an abstract class (#680)", {
   expect_snapshot(convert(Bar(), Foo), error = TRUE)
 })
 
+test_that("convert() errors when upcasting to an abstract S3 class (#686)", {
+  # An S3 class without a constructor is abstract, so there's no valid instance
+  # to convert to (class_POSIXt is the union of POSIXct and POSIXlt)
+  expect_snapshot(convert(.POSIXct(1), class_POSIXt), error = TRUE)
+})
+
 test_that("convert() falls back to as.*() for base type targets (#472)", {
   expect_identical(convert(1.5, class_character), "1.5")
   expect_identical(convert(c("1", "2"), class_integer), c(1L, 2L))

--- a/tests/testthat/test-super.R
+++ b/tests/testthat/test-super.R
@@ -48,6 +48,16 @@ describe("super()", {
     expect_equal(gen(super(my_int, to = class_integer)), "integer")
   })
 
+  it("works with abstract S3 classes (#686)", {
+    gen <- new_generic("gen", "x")
+    method(gen, class_POSIXct) <- function(x) "POSIXct"
+    method(gen, class_POSIXt) <- function(x) "POSIXt"
+
+    x <- .POSIXct(1)
+    expect_equal(gen(x), "POSIXct")
+    expect_equal(gen(super(x, to = class_POSIXt)), "POSIXt")
+  })
+
   it("works with S4 objects", {
     methods::setClass("Foo1", representation(x = "numeric"))
     methods::setClass("Foo2", contains = "Foo1")


### PR DESCRIPTION
* No longer error when constructing a class that inherits from an abstract S3 class
* Errors when upcasting to an abstract S3 class
* New test to confirm that `super()` works for an abstract S3 class.

No news bullet for the motivating issue since this was a bug introduced in the dev version.

Fixes #686