### PR TITLE
Use `local_s4_class()` + `:=` in more places

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -41,5 +41,7 @@
 
   cl[[1L]] <- quote(`<-`)
   cl[[3L]]$name <- as.character(cl[[2L]])
-  invisible(eval.parent(cl))
+
+  # Can't use eval because it introduces a new frame
+  invisible(.Call(S7_eval_bare_, cl, parent.frame()))
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -1,0 +1,11 @@
+#include "compat.h"
+
+// Evaluate `expr` in `env` without pushing an R-level evaluation context.
+// Unlike base `eval()` (and `eval.parent()`), this does not establish a
+// return context, so a function called in `expr` sees `env` as its
+// `parent.frame()`. `:=` relies on this so that helpers which capture
+// `parent.frame()` (e.g. for deferred cleanup) attach to the caller of `:=`
+// rather than a transient evaluation frame.
+SEXP S7_eval_bare_(SEXP expr, SEXP env) {
+  return Rf_eval(expr, env);
+}

--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,7 @@ extern SEXP S7_object_(void);
 extern SEXP prop_(SEXP, SEXP);
 extern SEXP prop_set_(SEXP, SEXP, SEXP, SEXP);
 extern SEXP prop_storage_rename_(SEXP);
+extern SEXP S7_eval_bare_(SEXP, SEXP);
 extern void prop_init(void);
 
 #define CALLDEF(name, n)  {#name, (DL_FUNC) &name, n}
@@ -21,6 +22,7 @@ static const R_CallMethodDef CallEntries[] = {
     CALLDEF(prop_, 2),
     CALLDEF(prop_set_, 4),
     CALLDEF(prop_storage_rename_, 1),
+    CALLDEF(S7_eval_bare_, 2),
     {NULL, NULL, 0}
 };
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -55,8 +55,19 @@ local_methods <- function(..., frame = parent.frame()) {
   invisible()
 }
 
-local_S4_class <- function(name, ..., env = parent.frame()) {
-  out <- methods::setClass(name, contains = "character")
+local_S4_class <- function(
+  name,
+  ...,
+  env = parent.frame(),
+  where = topenv(env)
+) {
+  out <- methods::setClass(name, ..., where = where)
+  defer(S4_remove_classes(name, env), env)
+  out
+}
+
+local_S4_union <- function(name, members, env = parent.frame()) {
+  out <- methods::setClassUnion(name, members, where = topenv(env))
   defer(S4_remove_classes(name, env), env)
   out
 }

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -1,6 +1,5 @@
 test_that("can work with classGenerators", {
-  on.exit(S4_remove_classes("Foo"))
-  Foo <- setClass("Foo")
+  Foo := local_S4_class()
   expect_equal(S4_to_S7_class(Foo), getClass("Foo"))
 })
 
@@ -34,19 +33,17 @@ test_that("converts S4 base classes to S7 base classes", {
 })
 
 test_that("converts S4 unions to S7 unions", {
-  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3", "Union1", "Union2")))
+  Foo1 := local_S4_class(slots = "x")
+  Foo2 := local_S4_class(slots = "x")
 
-  setClass("Foo1", slots = "x")
-  setClass("Foo2", slots = "x")
-
-  setClassUnion("Union1", c("Foo1", "Foo2"))
+  Union1 := local_S4_union(c("Foo1", "Foo2"))
   expect_equal(
     S4_to_S7_class(getClass("Union1")),
     new_union(getClass("Foo1"), getClass("Foo2"))
   )
 
-  setClass("Foo3", slots = "x")
-  setClassUnion("Union2", c("Union1", "Foo3"))
+  Foo3 := local_S4_class(slots = "x")
+  Union2 := local_S4_union(c("Union1", "Foo3"))
   expect_equal(
     S4_to_S7_class(getClass("Union2")),
     new_union(getClass("Foo1"), getClass("Foo2"), getClass("Foo3"))
@@ -67,17 +64,14 @@ test_that("errors on non-S4 classes", {
 
 
 test_that("S4_class_dispatch returns name of base class", {
-  on.exit(S4_remove_classes("Foo1"))
-  setClass("Foo1", slots = list("x" = "numeric"))
+  Foo1 := local_S4_class(slots = list("x" = "numeric"))
   expect_equal(S4_class_dispatch("Foo1"), "S4/S7::Foo1")
 })
 
 test_that("S4_class_dispatch respects single inheritance hierarchy", {
-  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3")))
-
-  setClass("Foo1", slots = list("x" = "numeric"))
-  setClass("Foo2", contains = "Foo1")
-  setClass("Foo3", contains = "Foo2")
+  Foo1 := local_S4_class(slots = list("x" = "numeric"))
+  Foo2 := local_S4_class(contains = "Foo1")
+  Foo3 := local_S4_class(contains = "Foo2")
   expect_equal(
     S4_class_dispatch("Foo3"),
     c("S4/S7::Foo3", "S4/S7::Foo2", "S4/S7::Foo1")
@@ -85,12 +79,11 @@ test_that("S4_class_dispatch respects single inheritance hierarchy", {
 })
 
 test_that("S4_class_dispatch performs breadth first search for multiple dispatch", {
-  on.exit(S4_remove_classes(c("Foo1a", "Foo1b", "Foo2a", "Foo2b", "Foo3")))
-  setClass("Foo1a", slots = list("x" = "numeric"))
-  setClass("Foo1b", contains = "Foo1a")
-  setClass("Foo2a", slots = list("x" = "numeric"))
-  setClass("Foo2b", contains = "Foo2a")
-  setClass("Foo3", contains = c("Foo1b", "Foo2b"))
+  Foo1a := local_S4_class(slots = list("x" = "numeric"))
+  Foo1b := local_S4_class(contains = "Foo1a")
+  Foo2a := local_S4_class(slots = list("x" = "numeric"))
+  Foo2b := local_S4_class(contains = "Foo2a")
+  Foo3 := local_S4_class(contains = c("Foo1b", "Foo2b"))
   expect_equal(
     S4_class_dispatch("Foo3"),
     c(
@@ -104,17 +97,15 @@ test_that("S4_class_dispatch performs breadth first search for multiple dispatch
 })
 
 test_that("S4_class_dispatch handles extensions of base classes", {
-  on.exit(S4_remove_classes("Foo1"))
-  setClass("Foo1", contains = "character")
+  Foo1 := local_S4_class(contains = "character")
   expect_equal(S4_class_dispatch("Foo1"), c("S4/S7::Foo1", "character"))
 })
 
 test_that("S4_class_dispatch handles extensions of S3 classes", {
-  on.exit(S4_remove_classes(c("Soo1", "Foo2", "Foo3")))
-
   setOldClass(c("Soo1", "Soo"))
-  setClass("Foo2", contains = "Soo1")
-  setClass("Foo3", contains = "Foo2")
+  defer(S4_remove_classes("Soo1"))
+  Foo2 := local_S4_class(contains = "Soo1")
+  Foo3 := local_S4_class(contains = "Foo2")
   expect_equal(
     S4_class_dispatch("Foo3"),
     c("S4/S7::Foo3", "S4/S7::Foo2", "Soo1", "Soo")
@@ -122,38 +113,31 @@ test_that("S4_class_dispatch handles extensions of S3 classes", {
 })
 
 test_that("S4_class_dispatch ignores unions", {
-  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3")))
-
-  setClass("Foo1", slots = list("x" = "numeric"))
-  setClass("Foo2", slots = list("x" = "numeric"))
-  setClassUnion("Foo3", c("Foo1", "Foo2"))
+  Foo1 := local_S4_class(slots = list("x" = "numeric"))
+  Foo2 := local_S4_class(slots = list("x" = "numeric"))
+  Foo3 := local_S4_union(c("Foo1", "Foo2"))
 
   expect_equal(S4_class_dispatch("Foo1"), "S4/S7::Foo1")
   expect_equal(S4_class_dispatch("Foo2"), "S4/S7::Foo2")
 })
 
 test_that("S4_class_dispatch includes virtual classes", {
-  on.exit(S4_remove_classes(c("Foo1", "Foo2")))
-
-  setClass("Foo1")
-  setClass("Foo2", contains = "Foo1")
+  Foo1 := local_S4_class()
+  Foo2 := local_S4_class(contains = "Foo1")
 
   expect_equal(S4_class_dispatch("Foo1"), "S4/S7::Foo1")
   expect_equal(S4_class_dispatch("Foo2"), c("S4/S7::Foo2", "S4/S7::Foo1"))
 })
 
 test_that("S4_class_dispatch captures explicit package name", {
-  on.exit(S4_remove_classes("Foo1"))
-  setClass("Foo1", package = "pkg")
+  Foo1 := local_S4_class(package = "pkg")
   expect_equal(S4_class_dispatch("Foo1"), "S4/pkg::Foo1")
 })
 
 test_that("S4_class_dispatch captures implicit package name", {
-  on.exit(S4_remove_classes("Foo1", env))
-
   env <- new.env()
   env$.packageName <- "mypkg"
-  setClass("Foo1", where = env)
+  Foo1 := local_S4_class(package = "mypkg")
   expect_equal(S4_class_dispatch("Foo1"), "S4/mypkg::Foo1")
 })
 

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -137,7 +137,7 @@ test_that("S4_class_dispatch captures explicit package name", {
 test_that("S4_class_dispatch captures implicit package name", {
   env <- new.env()
   env$.packageName <- "mypkg"
-  Foo1 := local_S4_class(package = "mypkg")
+  Foo1 := local_S4_class(where = env)
   expect_equal(S4_class_dispatch("Foo1"), "S4/mypkg::Foo1")
 })
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -14,6 +14,23 @@ test_that(":= returns the value invisibly", {
   expect_invisible(foo := new_thing())
 })
 
+test_that(":= defers rhs cleanup to the caller, not a transient eval frame", {
+  log <- new.env()
+  log$cleaned <- FALSE
+
+  record_cleanup <- function(log, name, frame = parent.frame()) {
+    defer(log$cleaned <- TRUE, frame = frame)
+    name
+  }
+  outer <- function() {
+    thing := record_cleanup(log)
+    log$cleaned
+  }
+
+  expect_false(outer()) # outer is still running
+  expect_true(log$cleaned) # but fires once outer() returns
+})
+
 test_that(":= validates its inputs", {
   new_thing <- function(name) list(name = name)
   no_name <- function() "x"

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -215,12 +215,10 @@ test_that("can work with S7 classes that extend S3 classes", {
 # S4 ----------------------------------------------------------------------
 
 test_that("can work with S4 classes", {
-  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3", "Foo4")))
-
-  methods::setClass("Foo1", contains = "character")
-  methods::setClass("Foo2", contains = "Foo1")
-  methods::setClass("Foo3", slots = list(x = "numeric"))
-  methods::setClass("Foo4", contains = c("Foo2", "Foo3"))
+  Foo1 := local_S4_class(contains = "character")
+  Foo2 := local_S4_class(contains = "Foo1")
+  Foo3 := local_S4_class(slots = list(x = "numeric"))
+  Foo4 := local_S4_class(contains = c("Foo2", "Foo3"))
 
   klass <- methods::getClass("Foo4")
 

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -61,7 +61,7 @@ test_that("S7 classes check inputs", {
 })
 
 test_that("S7 classes can't inherit from S4 or class unions", {
-  parentS4 <- methods::setClass("parentS4", slots = c(x = "numeric"))
+  parentS4 := local_S4_class(slots = c(x = "numeric"))
   expect_snapshot(error = TRUE, {
     new_class("test", parent = parentS4)
     new_class("test", parent = new_union("character"))
@@ -94,15 +94,8 @@ test_that("inheritance lets child properties narrow the parent's type", {
 })
 
 test_that("inheritance lets child properties narrow with S4 inheritance", {
-  on.exit(S4_remove_classes(c("S4PropertyParent", "S4PropertyChild")))
-  S4PropertyParent <- methods::setClass(
-    "S4PropertyParent",
-    slots = c(x = "numeric")
-  )
-  S4PropertyChild <- methods::setClass(
-    "S4PropertyChild",
-    contains = "S4PropertyParent"
-  )
+  S4PropertyParent := local_S4_class(slots = c(x = "numeric"))
+  S4PropertyChild := local_S4_class(contains = "S4PropertyParent")
 
   Parent <- new_class(
     "Parent",

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -38,7 +38,7 @@ test_that("single dispatch works for S3 objects", {
 test_that("single dispatch works for S4 objects", {
   foo := new_generic("x")
 
-  my_S4 <- setClass("my_S4", contains = "numeric")
+  my_S4 := local_S4_class(contains = "numeric")
   method(foo, my_S4) <- function(x) "S4"
 
   expect_equal(foo(my_S4(1)), "S4")
@@ -165,8 +165,7 @@ test_that("single dispatch fails with informative messages", {
   fail := new_generic("x")
 
   foo := new_class(package = NULL)
-  Foo <- setClass("Foo", slots = list("x" = "numeric"))
-  on.exit(S4_remove_classes("Foo"))
+  Foo := local_S4_class(slots = list("x" = "numeric"))
 
   expect_snapshot(error = TRUE, {
     fail(TRUE)
@@ -182,8 +181,7 @@ test_that("multiple dispatch fails with informative messages", {
   fail := new_generic(c("x", "y"))
 
   foo := new_class()
-  Foo <- setClass("Foo", slots = list("x" = "numeric"))
-  on.exit(S4_remove_classes("Foo"))
+  Foo := local_S4_class(slots = list("x" = "numeric"))
 
   expect_snapshot(error = TRUE, {
     fail(TRUE)

--- a/tests/testthat/test-method-ops.R
+++ b/tests/testthat/test-method-ops.R
@@ -50,7 +50,7 @@ test_that("operator methods on S3/S4 classes work when neither operand is S7", {
   method(`+`, list(class_foo, class_any)) <- function(e1, e2) "foo+any"
   expect_equal(foo + 10, "foo+any")
 
-  fooS4 <- local_S4_class("fooS4")
+  fooS4 := local_S4_class(contains = "character")
   method(`+`, list(fooS4, class_any)) <- function(e1, e2) "fooS4+any"
   expect_equal(fooS4("x") + 10, "fooS4+any")
 
@@ -77,7 +77,7 @@ test_that("operator bridge does not clobber an existing group method", {
 
 test_that("Ops generics dispatch to S7 methods for S4 classes", {
   local_methods(base_ops[["+"]])
-  fooS4 <- local_S4_class("fooS4", contains = "character")
+  fooS4 := local_S4_class(contains = "character")
   fooS7 := new_class()
 
   method(`+`, list(fooS7, fooS4)) <- function(e1, e2) "S7-S4"

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -430,7 +430,7 @@ test_that("new_property() displays nicely", {
 
 test_that("properties can be base, S3, S4, S7, or S7 union", {
   class_S7 := new_class(package = NULL)
-  class_S4 <- methods::setClass("class_S4", slots = c(x = "numeric"))
+  class_S4 := local_S4_class(slots = c(x = "numeric"))
 
   my_class := new_class(
     package = NULL,
@@ -532,14 +532,12 @@ test_that("property validation runs the class's own validator", {
 })
 
 test_that("property validation runs an S4 class's validity method", {
-  PosNum <- methods::setClass(
-    "PosNum",
+  PosNum := local_S4_class(
     slots = c(n = "numeric"),
     validity = function(object) {
       if (object@n <= 0) "n must be positive" else TRUE
     }
   )
-  on.exit(S4_remove_classes("PosNum"))
   Foo := new_class(package = NULL, properties = list(x = PosNum))
 
   # An S4 object that passes the structural check but fails its own validity

--- a/tests/testthat/test-super.R
+++ b/tests/testthat/test-super.R
@@ -58,9 +58,8 @@ test_that("super() works with abstract S3 classes (#686)", {
 })
 
 test_that("super() works with S4 objects", {
-  methods::setClass("Foo1", representation(x = "numeric"))
-  methods::setClass("Foo2", contains = "Foo1")
-  on.exit(S4_remove_classes(c("Foo1", "Foo2")))
+  Foo1 := local_S4_class(representation(x = "numeric"))
+  Foo2 := local_S4_class(contains = "Foo1")
   obj <- methods::new("Foo2", x = 5)
 
   gen := new_generic("x")

--- a/tests/testthat/test-union.R
+++ b/tests/testthat/test-union.R
@@ -35,8 +35,7 @@ test_that("base unions display as expected", {
 })
 
 test_that("can construct from S3 and S4 classes", {
-  S4_union <- methods::setClass("S4_union")
-  on.exit(S4_remove_classes("S4_union"))
+  S4_union := local_S4_class()
 
   u <- new_union(class_factor, S4_union)
   expect_equal(u$classes, list(class_factor, getClass("S4_union")))
@@ -44,10 +43,9 @@ test_that("can construct from S3 and S4 classes", {
 
 test_that("can construct with |", {
   foo := new_class()
-  Foo1 <- setClass("Foo1", slots = list("x" = "numeric"))
-  Foo2 <- setClass("Foo2", slots = list("x" = "numeric"))
-  Foo3 <- setClassUnion("Foo3", c("Foo1", "Foo2"))
-  on.exit(S4_remove_classes(c("Foo1", "Foo2", "Foo3")))
+  Foo1 := local_S4_class(slots = list("x" = "numeric"))
+  Foo2 := local_S4_class(slots = list("x" = "numeric"))
+  Foo3 := local_S4_union(c("Foo1", "Foo2"))
 
   expect_equal(class_integer | class_double, class_numeric)
   expect_equal(class_integer | class_numeric, class_numeric)


### PR DESCRIPTION
Since it automatically cleans up the class. This revealed a small bug in `:=`, which I think is worth fixing (and it's an easy fix if we assume that `:=` eventually ends up in base R).

Fixes #700