### PR TITLE
Test style polishing

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -55,8 +55,8 @@ local_methods <- function(..., frame = parent.frame()) {
   invisible()
 }
 
-# Simulate a package with namesapce
-local_package <- function(name, ..., frame = parent.frame()) {
+# Simulate a package with namespace
+local_package <- function(name, code = {}, frame = parent.frame()) {
   ns <- new.env(parent = asNamespace("S7"))
 
   info <- new.env(parent = emptyenv())
@@ -71,9 +71,7 @@ local_package <- function(name, ..., frame = parent.frame()) {
   defer(internal(unregisterNamespace(name)), frame = frame)
   defer(S7_on_unload_(ns), frame = frame)
 
-  for (expr in eval(substitute(alist(...)))) {
-    eval(expr, ns)
-  }
+  eval(substitute(code), ns)
 
   ns
 }

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -103,8 +103,8 @@ test_that("class_inherits handles variation in class names", {
 })
 
 test_that("class_extends checks subclass relationship between classes", {
-  Parent <- new_class("Parent", package = NULL)
-  Child <- new_class("Child", parent = Parent, package = NULL)
+  Parent := new_class(package = NULL)
+  Child := new_class(parent = Parent, package = NULL)
 
   expect_true(class_extends(Child, Parent))
   expect_true(class_extends(Child, Child))

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -82,9 +82,9 @@ test_that("inheritance lets child properties override parent", {
 })
 
 test_that("inheritance lets child properties narrow the parent's type", {
-  Parent <- new_class("Parent", package = NULL)
-  Child <- new_class("Child", parent = Parent, package = NULL)
-  foo1 <- new_class("foo1", properties = list(x = Parent))
+  Parent := new_class(package = NULL)
+  Child := new_class(parent = Parent, package = NULL)
+  foo1 := new_class(properties = list(x = Parent))
   expect_no_error(new_class("foo2", foo1, properties = list(x = Child)))
   expect_no_error(new_class(
     "foo3",
@@ -97,14 +97,12 @@ test_that("inheritance lets child properties narrow with S4 inheritance", {
   S4PropertyParent := local_S4_class(slots = c(x = "numeric"))
   S4PropertyChild := local_S4_class(contains = "S4PropertyParent")
 
-  Parent <- new_class(
-    "Parent",
+  Parent := new_class(
     properties = list(x = S4PropertyParent),
     package = NULL
   )
-  Child <- new_class(
-    "Child",
-    Parent,
+  Child := new_class(
+    parent = Parent,
     properties = list(x = S4PropertyChild),
     package = NULL
   )
@@ -114,8 +112,7 @@ test_that("inheritance lets child properties narrow with S4 inheritance", {
 })
 
 test_that("inheritance doesn't let child properties narrow S7_object with base or S3 classes", {
-  Parent <- new_class(
-    "Parent",
+  Parent := new_class(
     properties = list(x = S7_object),
     package = NULL,
     abstract = TRUE
@@ -142,8 +139,7 @@ test_that("inheritance doesn't let child properties narrow S7_object with base o
 })
 
 test_that("inheritance lets child properties narrow parent unions that include any", {
-  Parent <- new_class(
-    "Parent",
+  Parent := new_class(
     properties = list(x = class_any | class_integer),
     package = NULL
   )
@@ -156,23 +152,20 @@ test_that("inheritance lets child properties narrow parent unions that include a
 })
 
 test_that("inheritance lets child properties narrow optional union properties with NULL", {
-  Parent <- new_class(
-    "Parent",
+  Parent := new_class(
     properties = list(x = NULL | class_numeric),
     package = NULL
   )
 
-  NullChild <- new_class(
-    "NullChild",
-    Parent,
+  NullChild := new_class(
+    parent = Parent,
     properties = list(x = NULL),
     package = NULL
   )
   expect_equal(NullChild()@x, NULL)
 
-  OptionalIntegerChild <- new_class(
-    "OptionalIntegerChild",
-    Parent,
+  OptionalIntegerChild := new_class(
+    parent = Parent,
     properties = list(x = NULL | class_integer),
     package = NULL
   )
@@ -181,8 +174,7 @@ test_that("inheritance lets child properties narrow optional union properties wi
 })
 
 test_that("inheritance doesn't let child properties widen or change the parent's type", {
-  foo1 <- new_class(
-    "foo1",
+  foo1 := new_class(
     properties = list(x = class_integer),
     package = NULL
   )
@@ -194,7 +186,7 @@ test_that("inheritance doesn't let child properties widen or change the parent's
 })
 
 test_that("inheritance lets dynamic child properties override any parent type", {
-  foo1 <- new_class("foo1", properties = list(x = class_integer))
+  foo1 := new_class(properties = list(x = class_integer))
   readonly <- new_property(class_character, getter = function(self) "x")
   expect_no_error(new_class("foo2", foo1, properties = list(x = readonly)))
 })
@@ -458,8 +450,7 @@ test_that("can round trip to disk and back", {
 test_that("objects from a previous version of S7 still work (#677)", {
   # Older versions of S7 stored the class object in the `S7_class` attribute
   # rather than `_S7_class`.
-  Foo <- new_class(
-    "Foo",
+  Foo := new_class(
     parent = class_double,
     properties = list(x = class_numeric)
   )

--- a/tests/testthat/test-external-generic.R
+++ b/tests/testthat/test-external-generic.R
@@ -3,7 +3,7 @@ test_that("can get and append methods", {
 
   expect_equal(S7_methods_table("testpkg"), list())
 
-  bar <- new_external_generic("foo", "bar", "x")
+  bar := new_external_generic("foo", dispatch_args = "x")
   external_methods_add("testpkg", bar, list(), function() {})
   expect_equal(
     S7_methods_table("testpkg"),
@@ -20,7 +20,7 @@ test_that("can get and append methods", {
 test_that("re-adding a method replaces the existing entry", {
   local_package("testpkg")
 
-  bar <- new_external_generic("foo", "bar", "x")
+  bar := new_external_generic("foo", dispatch_args = "x")
   external_methods_add("testpkg", bar, list("A"), function() "a")
   external_methods_add("testpkg", bar, list("A"), function() "b")
   expect_length(S7_methods_table("testpkg"), 1)
@@ -30,8 +30,8 @@ test_that("re-adding a method replaces the existing entry", {
 test_that("can remove methods", {
   local_package("testpkg")
 
-  bar <- new_external_generic("foo", "bar", "x")
-  baz <- new_external_generic("foo", "baz", "x")
+  bar := new_external_generic("foo", dispatch_args = "x")
+  baz := new_external_generic("foo", dispatch_args = "x")
   external_methods_add("testpkg", bar, list("A"), function() "a")
   external_methods_add("testpkg", baz, list("B"), function() "b")
   expect_length(S7_methods_table("testpkg"), 2)
@@ -46,22 +46,24 @@ test_that("can remove methods", {
 })
 
 test_that("displays nicely", {
-  bar <- new_external_generic("foo", "bar", "x")
+  bar := new_external_generic("foo", dispatch_args = "x")
   expect_snapshot({
     print(bar)
   })
 })
 
 test_that("can convert existing generics to external", {
-  ns <- local_package("test", foo_S7 := new_generic("x"))
+  ns <- local_package("test", {
+    foo_S7 := new_generic("x")
+  })
 
   expect_equal(
     as_external_generic(ns$foo_S7),
     new_external_generic("test", "foo_S7", "x")
   )
 
-  foo_ext <- new_external_generic("pkg", "foo", "x")
-  expect_equal(as_external_generic(foo_ext), foo_ext)
+  foo := new_external_generic("pkg", dispatch_args = "x")
+  expect_equal(as_external_generic(foo), foo)
 
   expect_equal(
     as_external_generic(as_S3_generic(sum)),

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -1,13 +1,14 @@
 test_that("S7_on_load() doesn't accumulate hooks across repeated loads", {
-  upstream <- local_package("upstream", gen := new_generic("x"))
+  upstream <- local_package("upstream", {
+    gen := new_generic("x")
+  })
   expect_length(package_hooks("upstream"), 0)
 
-  downstream <- local_package(
-    "downstream",
-    Foo := new_class(),
-    gen := new_external_generic("upstream", dispatch_args = "x"),
+  downstream <- local_package("downstream", {
+    Foo := new_class()
+    gen := new_external_generic("upstream", dispatch_args = "x")
     method(gen, Foo) <- \(x) "dispatched"
-  )
+  })
   S7_on_load_(downstream)
   expect_length(package_hooks("upstream"), 1)
   S7_on_load_(downstream)
@@ -15,13 +16,14 @@ test_that("S7_on_load() doesn't accumulate hooks across repeated loads", {
 })
 
 test_that("S7_on_unload() unregisters methods and removes hooks", {
-  upstream <- local_package("upstream", gen := new_generic("x"))
-  downstream <- local_package(
-    "downstream",
-    Foo := new_class(),
-    gen := new_external_generic("upstream", dispatch_args = "x"),
+  upstream <- local_package("upstream", {
+    gen := new_generic("x")
+  })
+  downstream <- local_package("downstream", {
+    Foo := new_class()
+    gen := new_external_generic("upstream", dispatch_args = "x")
     method(gen, Foo) <- \(x) "dispatched"
-  )
+  })
   S7_on_load_(downstream)
 
   S7_on_unload_(downstream)
@@ -35,13 +37,12 @@ test_that("S7_on_unload() unregisters methods and removes hooks", {
 test_that("S7_on_unload() unregisters base operator methods", {
   local_methods(base_ops[["+"]])
 
-  downstream <- local_package(
-    "downstream_base_ops_unload",
-    .onLoad <- function(...) S7_on_load(),
-    .onUnload <- function(...) S7_on_unload(),
-    Foo := new_class(),
+  downstream <- local_package("downstream_base_ops_unload", {
+    .onLoad <- function(...) S7_on_load()
+    .onUnload <- function(...) S7_on_unload()
+    Foo := new_class()
     method(`+`, list(Foo, Foo)) <- function(e1, e2) "dispatched"
-  )
+  })
   downstream$.onLoad()
   expect_equal(downstream$Foo() + downstream$Foo(), "dispatched")
 
@@ -53,26 +54,26 @@ test_that("S7_on_unload() unregisters base operator methods", {
 })
 
 test_that("S7_on_unload() doesn't remove methods registered by another package", {
-  upstream <- local_package("upstream_conflict", gen := new_generic("x"))
-  first <- local_package(
-    "downstream_first",
-    .onLoad <- function(...) S7_on_load(),
-    .onUnload <- function(...) S7_on_unload(),
-    gen := new_external_generic("upstream_conflict", dispatch_args = "x"),
+  upstream <- local_package("upstream_conflict", {
+    gen := new_generic("x")
+  })
+  first <- local_package("downstream_first", {
+    .onLoad <- function(...) S7_on_load()
+    .onUnload <- function(...) S7_on_unload()
+    gen := new_external_generic("upstream_conflict", dispatch_args = "x")
     method(gen, class_character) <- function(x) "first"
-  )
+  })
   first$.onLoad()
   expect_equal(upstream$gen("x"), "first")
 
   second <- NULL
   expect_message(
-    second <- local_package(
-      "downstream_second",
-      .onLoad <- function(...) S7_on_load(),
-      .onUnload <- function(...) S7_on_unload(),
-      gen := new_external_generic("upstream_conflict", dispatch_args = "x"),
+    second <- local_package("downstream_second", {
+      .onLoad <- function(...) S7_on_load()
+      .onUnload <- function(...) S7_on_unload()
+      gen := new_external_generic("upstream_conflict", dispatch_args = "x")
       method(gen, class_character) <- function(x) "second"
-    ),
+    }),
     "Overwriting method"
   )
   second$.onLoad()
@@ -83,15 +84,16 @@ test_that("S7_on_unload() doesn't remove methods registered by another package",
 })
 
 test_that("S7_on_load() removes hooks for deleted external methods", {
-  upstream <- local_package("upstream_deleted", gen := new_generic("x"))
-  downstream <- local_package(
-    "downstream_deleted",
-    .onLoad <- function(...) S7_on_load(),
-    .onUnload <- function(...) S7_on_unload(),
-    Foo := new_class(),
-    gen := new_external_generic("upstream_deleted", dispatch_args = "x"),
+  upstream <- local_package("upstream_deleted", {
+    gen := new_generic("x")
+  })
+  downstream <- local_package("downstream_deleted", {
+    .onLoad <- function(...) S7_on_load()
+    .onUnload <- function(...) S7_on_unload()
+    Foo := new_class()
+    gen := new_external_generic("upstream_deleted", dispatch_args = "x")
     method(gen, Foo) <- function(x) "dispatched"
-  )
+  })
   downstream$.onLoad()
   expect_length(package_hooks("upstream_deleted"), 1)
 
@@ -110,21 +112,19 @@ test_that("S7_on_load() removes hooks for deleted external methods", {
 })
 
 test_that("S7_on_unload() honors external generic version gates", {
-  downstream <- local_package(
-    "downstream_version_gate_unload",
-    .onLoad <- function(...) S7_on_load(),
-    .onUnload <- function(...) S7_on_unload(),
+  downstream <- local_package("downstream_version_gate_unload", {
+    .onLoad <- function(...) S7_on_load()
+    .onUnload <- function(...) S7_on_unload()
     gen := new_external_generic(
       "upstream_version_gate_unload",
       dispatch_args = "x",
       version = "1.0.0"
-    ),
+    )
     method(gen, class_character) <- function(x) "downstream"
-  )
-  upstream <- local_package(
-    "upstream_version_gate_unload",
+  })
+  upstream <- local_package("upstream_version_gate_unload", {
     gen <- function(x) "not an S7 generic"
-  )
+  })
 
   downstream$.onLoad()
   expect_equal(upstream$gen("x"), "not an S7 generic")
@@ -151,8 +151,9 @@ test_that("S7_on_unload() unregisters methods when a real package is unloaded (#
 test_that("S7_on_build() removes only generic sentinels from the namespace", {
   ns <- new.env(parent = emptyenv())
   ns$keep_fun <- function() {}
-  ns$keep_ext <- new_external_generic("pkg", "gen", "x")
-  ns$drop_me <- generic_sentinel(new_external_generic("pkg", "gen", "x"))
+  gen := new_external_generic("pkg", dispatch_args = "x")
+  ns$keep_ext <- gen
+  ns$drop_me <- generic_sentinel(gen)
 
   strip_generic_sentinels(ns)
   expect_setequal(names(ns), c("keep_ext", "keep_fun"))

--- a/tests/testthat/test-introspect.R
+++ b/tests/testthat/test-introspect.R
@@ -6,9 +6,9 @@ test_that("S7_classes() / S7_generics() inspect a single environment", {
 
 test_that("default `env` is the caller's environment", {
   local({
-    Foo <- new_class("Foo", package = NULL)
-    Bar <- new_class("Bar", package = NULL)
-    my_gen <- new_generic("my_gen", "x")
+    Foo := new_class(package = NULL)
+    Bar := new_class(package = NULL)
+    my_gen := new_generic("x")
 
     expect_setequal(S7_classes(), c("Foo", "Bar"))
     expect_setequal(S7_generics(), "my_gen")
@@ -19,9 +19,9 @@ test_that("default `env` is the caller's environment", {
 })
 
 test_that("S7_methods(generic) lists registered methods", {
-  Foo <- new_class("Foo", package = NULL)
-  Bar <- new_class("Bar", package = NULL)
-  gen <- new_generic("gen", "x")
+  Foo := new_class(package = NULL)
+  Bar := new_class(package = NULL)
+  gen := new_generic("x")
   method(gen, Foo) <- function(x) "foo"
   method(gen, Bar) <- function(x) "bar"
 
@@ -33,9 +33,9 @@ test_that("S7_methods(generic) lists registered methods", {
 })
 
 test_that("S7_methods() prints the signature column readably", {
-  Foo <- new_class("Foo", package = NULL)
-  Bar <- new_class("Bar", package = NULL)
-  gen <- new_generic("gen", "x")
+  Foo := new_class(package = NULL)
+  Bar := new_class(package = NULL)
+  gen := new_generic("x")
   method(gen, Foo) <- function(x) "foo"
   method(gen, Bar) <- function(x) "bar"
 
@@ -43,7 +43,7 @@ test_that("S7_methods() prints the signature column readably", {
 })
 
 test_that("S7_signature_list formats per element", {
-  foo <- new_generic("foo", c("x", "y"))
+  foo := new_generic(c("x", "y"))
   sigs <- new_signature_list(list(
     as_signature(list(class_integer, class_character), foo),
     as_signature(list(class_double, class_logical), foo)
@@ -56,9 +56,9 @@ test_that("S7_signature_list formats per element", {
 })
 
 test_that("S7_methods(generic) handles multi-dispatch", {
-  Foo <- new_class("Foo", package = NULL)
-  Bar <- new_class("Bar", package = NULL)
-  gen <- new_generic("gen", c("x", "y"))
+  Foo := new_class(package = NULL)
+  Bar := new_class(package = NULL)
+  gen := new_generic(c("x", "y"))
   method(gen, list(Foo, Bar)) <- function(x, y) "fb"
 
   res <- S7_methods(generic = gen)
@@ -66,7 +66,7 @@ test_that("S7_methods(generic) handles multi-dispatch", {
 })
 
 test_that("S7_methods(generic) returns empty df when no methods", {
-  gen <- new_generic("gen", "x")
+  gen := new_generic("x")
   res <- S7_methods(generic = gen)
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), 0)
@@ -74,8 +74,8 @@ test_that("S7_methods(generic) returns empty df when no methods", {
 })
 
 test_that("S7_methods(class) scans attached generics", {
-  Foo <- new_class("Foo", package = NULL)
-  Bar <- new_class("Bar", package = NULL)
+  Foo := new_class(package = NULL)
+  Bar := new_class(package = NULL)
   g1 <- new_generic("S7_introspect_g1_xyzzy", "x")
   g2 <- new_generic("S7_introspect_g2_xyzzy", "x")
   method(g1, Foo) <- function(x) "foo"
@@ -98,8 +98,8 @@ test_that("S7_methods(class) scans attached generics", {
 })
 
 test_that("S7_methods() reports the generic's package", {
-  Foo <- new_class("Foo", package = NULL)
-  gen <- new_generic("gen", "x")
+  Foo := new_class(package = NULL)
+  gen := new_generic("x")
   method(gen, Foo) <- function(x) "foo"
 
   res <- S7_methods(generic = gen)

--- a/tests/testthat/test-method-register.R
+++ b/tests/testthat/test-method-register.R
@@ -69,10 +69,10 @@ test_that("method registration returns a strippable sentinel for foreign generic
   on.exit(external_methods_reset("S7"), add = TRUE)
 
   foo := new_class(package = NULL)
-  ext <- new_external_generic("notloaded.pkg", "ext_gen", "x")
+  ext_gen := new_external_generic("notloaded.pkg", dispatch_args = "x")
 
   out <- register_method(
-    ext,
+    ext_gen,
     foo,
     function(x) "x",
     env = asNamespace("S7"),
@@ -178,7 +178,7 @@ test_that("as_signature() works with NULL", {
 })
 
 test_that("S7_signature has format and print methods", {
-  foo <- new_generic("foo", c("x", "y"))
+  foo := new_generic(c("x", "y"))
   sig <- as_signature(list(class_integer, class_character), foo)
 
   expect_equal(format(sig), "<integer>, <character>")

--- a/tests/testthat/test-super.R
+++ b/tests/testthat/test-super.R
@@ -48,7 +48,7 @@ test_that("super() works with S3 objects", {
 })
 
 test_that("super() works with abstract S3 classes (#686)", {
-  gen <- new_generic("gen", "x")
+  gen := new_generic("x")
   method(gen, class_POSIXct) <- function(x) "POSIXct"
   method(gen, class_POSIXt) <- function(x) "POSIXt"
 


### PR DESCRIPTION
## Summary
- Update so `local_package()` takes a single `code` block instead of `...`.
- Update tests to use the newer constructor style with named arguments and `:=`, matching the package’s current API conventions.

Fixes #705