### PR TITLE
high priorty S4 compatibility fixes

### DIFF
--- a/R/S4.R
+++ b/R/S4.R
@@ -239,15 +239,14 @@ S4_check_contains <- function(class, call = sys.call(-1L)) {
   }
 
   for (prop in class@properties) {
-    if (prop_is_dynamic(prop) || prop_has_setter(prop)) {
+    if (prop_is_encapsulated(prop)) {
       msg <- sprintf(
         paste0(
           "Can't extend S7 class %s with S4 because property %s has a ",
-          "custom %s."
+          "custom getter or setter."
         ),
         class_desc(class),
-        prop$name,
-        if (prop_is_dynamic(prop)) "getter" else "setter"
+        prop$name
       )
       stop2(msg, call = call)
     }

--- a/R/S4.R
+++ b/R/S4.R
@@ -416,6 +416,18 @@ S4_initialize <- function(.Object, ...) {
     S4_check_contains(S7_class(.Object))
   }
 
+  if (!isS4(.Object)) {
+    class <- S7_class(.Object)
+    parent <- S4_ancestor(class)
+    parent_initialize <- methods::selectMethod(
+      "initialize",
+      parent@className
+    )
+    if (!inherits(parent_initialize, "derivedDefaultMethod")) {
+      return(parent_initialize(.Object, ...))
+    }
+  }
+
   args <- list(...)
   if (length(args) == 0) {
     return(.Object)

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -412,6 +412,8 @@ class_extends_S4_name <- function(class) {
     class@className
   } else if (is_class(class)) {
     S7_class_name(class)
+  } else {
+     NULL
   }
 }
 

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -413,7 +413,7 @@ class_extends_S4_name <- function(class) {
   } else if (is_class(class)) {
     S7_class_name(class)
   } else {
-     NULL
+    NULL
   }
 }
 

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -396,12 +396,22 @@ class_extends <- function(child, parent) {
     parent <- resolve_external_class_req(parent)
     class_extends(child, parent)
   } else if (is_S4_class(child) || is_S4_class(parent)) {
-    is_S4_class(child) &&
-      is_S4_class(parent) &&
-      methods::extends(child@className, parent@className)
+    child <- class_extends_S4_name(child)
+    parent <- class_extends_S4_name(parent)
+    !is.null(child) &&
+      !is.null(parent) &&
+      methods::extends(child, parent)
   } else {
     # handle S7, S3, and base types.
     class_dispatch_extends(class_dispatch(parent), class_dispatch(child))
+  }
+}
+
+class_extends_S4_name <- function(class) {
+  if (is_S4_class(class)) {
+    class@className
+  } else if (is_class(class)) {
+    S7_class_name(class)
   }
 }
 

--- a/R/class.R
+++ b/R/class.R
@@ -347,7 +347,7 @@ check_parent <- function(parent, class, call = sys.call(-1L)) {
 #' @rdname new_class
 #' @export
 new_object <- function(`_parent`, ...) {
-  class <- sys.function(-1)
+  class <- sys.function(sys.parent())
   if (!inherits(class, "S7_class")) {
     stop2("`new_object()` must be called from within a constructor.")
   }

--- a/R/class.R
+++ b/R/class.R
@@ -485,10 +485,7 @@ check_prop_overrides <- function(
   call = sys.call(-1L)
 ) {
   overridden <- intersect(names(child_props), names(parent_props))
-  parent_S4 <- if (is_S4_class(parent)) parent else S4_ancestor(parent)
-  if (!is.null(parent_S4)) {
-    check_S4_slot_overrides(child_props, parent_S4, call = call)
-  }
+  check_S4_slot_overrides(child_props, parent, call = call)
 
   for (prop in overridden) {
     child_prop <- child_props[[prop]]
@@ -523,9 +520,14 @@ check_prop_overrides <- function(
 
 check_S4_slot_overrides <- function(
   child_props,
-  parent_S4,
+  parent,
   call = sys.call(-1L)
 ) {
+  parent_S4 <- if (is_S4_class(parent)) parent else S4_ancestor(parent)
+  if (is.null(parent_S4)) {
+    return(invisible())
+  }
+
   overridden <- intersect(names(child_props), names(parent_S4@slots))
 
   for (prop in overridden) {
@@ -543,4 +545,6 @@ check_S4_slot_overrides <- function(
     )
     stop2(msg, call = call)
   }
+
+  invisible()
 }

--- a/R/class.R
+++ b/R/class.R
@@ -485,6 +485,10 @@ check_prop_overrides <- function(
   call = sys.call(-1L)
 ) {
   overridden <- intersect(names(child_props), names(parent_props))
+  parent_S4 <- if (is_S4_class(parent)) parent else S4_ancestor(parent)
+  if (!is.null(parent_S4)) {
+    check_S4_slot_overrides(child_props, parent_S4, call = call)
+  }
 
   for (prop in overridden) {
     child_prop <- child_props[[prop]]
@@ -514,5 +518,29 @@ check_prop_overrides <- function(
       )
       stop2(msg, call = call)
     }
+  }
+}
+
+check_S4_slot_overrides <- function(
+  child_props,
+  parent_S4,
+  call = sys.call(-1L)
+) {
+  overridden <- intersect(names(child_props), names(parent_S4@slots))
+
+  for (prop in overridden) {
+    child_prop <- child_props[[prop]]
+    if (!prop_is_encapsulated(child_prop)) {
+      next
+    }
+
+    msg <- sprintf(
+      paste0(
+        "Can't override inherited S4 slot %s with a property that has a ",
+        "custom getter or setter."
+      ),
+      prop
+    )
+    stop2(msg, call = call)
   }
 }

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -38,6 +38,14 @@ new_constructor <- function(
         bquote(S7::new_object(.(parent_call), ..(self_args)), splice = TRUE)
       }
 
+    if (is_S4_class(parent)) {
+      parent_nms <- names2(class_properties(parent))
+      new_object_call <- as.call(c(
+        list(quote(methods::initialize), new_object_call),
+        as_names(parent_nms)
+      ))
+    }
+
     return(new_S7_constructor(
       new_function(
         args = arg_info$self,

--- a/R/method-register-S3.R
+++ b/R/method-register-S3.R
@@ -5,6 +5,7 @@ register_S3_method <- function(
   envir = parent.frame(),
   call = sys.call(-1L)
 ) {
+  S4_envir <- envir
   sig <- signature[[1]]
 
   class <- switch(
@@ -31,7 +32,7 @@ register_S3_method <- function(
   }
 
   if (should_register_S4_method(generic, signature)) {
-    register_S4_method(generic$name, signature, method, envir, call = call)
+    register_S4_method(generic$name, signature, method, S4_envir, call = call)
   }
 }
 

--- a/R/method-register-S3.R
+++ b/R/method-register-S3.R
@@ -5,7 +5,6 @@ register_S3_method <- function(
   envir = parent.frame(),
   call = sys.call(-1L)
 ) {
-  S4_envir <- envir
   sig <- signature[[1]]
 
   class <- switch(
@@ -27,12 +26,12 @@ register_S3_method <- function(
     register_local_s3_method(generic, class, method)
   } else {
     # Register external generics in their own namespace.
-    envir <- environment(generic$generic) %||% envir
-    registerS3method(generic$name, class, method, envir)
+    S3_envir <- environment(generic$generic) %||% envir
+    registerS3method(generic$name, class, method, S3_envir)
   }
 
   if (should_register_S4_method(generic, signature)) {
-    register_S4_method(generic$name, signature, method, S4_envir, call = call)
+    register_S4_method(generic$name, signature, method, envir, call = call)
   }
 }
 

--- a/R/property.R
+++ b/R/property.R
@@ -608,3 +608,7 @@ prop_is_read_only <- function(prop) {
 prop_has_setter <- function(prop) is.function(prop$setter)
 
 prop_is_dynamic <- function(prop) is.function(prop$getter)
+
+prop_is_encapsulated <- function(prop) {
+  prop_is_dynamic(prop) || prop_has_setter(prop)
+}

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -702,6 +702,65 @@ test_that("S7 classes can extend S4 classes", {
   expect_error(Child(x = "x", y = "a"))
 })
 
+test_that("S7 constructors dispatch to S4 parent initialize methods", {
+  defer(S4_remove_classes(c(
+    "S4regParentInitialize",
+    "S4regChildInitialize",
+    "S4regVirtualInitialize",
+    "S4regVirtualChildInitialize"
+  )))
+  setClass("S4regParentInitialize", slots = list(x = "ANY", y = "matrix"))
+  setMethod(
+    "initialize",
+    "S4regParentInitialize",
+    function(.Object, x = NULL, y, value = x) {
+      .Object@x <- list(value)
+      .Object@y <- y + 1
+      .Object
+    }
+  )
+  S4regChildInitialize := new_class(
+    parent = getClass("S4regParentInitialize"),
+    package = NULL
+  )
+
+  y <- matrix(1, nrow = 1)
+  object <- S4regChildInitialize(x = 1, y = y)
+
+  expect_equal(object@x, list(1))
+  expect_equal(object@y, y + 1)
+  expect_identical(methods::validObject(object), TRUE)
+
+  object <- methods::initialize(object, value = 2, y = y)
+  expect_equal(object@x, list(2))
+  expect_equal(object@y, y + 1)
+
+  setClass(
+    "S4regVirtualInitialize",
+    contains = "VIRTUAL",
+    slots = list(x = "ANY", y = "matrix")
+  )
+  setMethod(
+    "initialize",
+    "S4regVirtualInitialize",
+    function(.Object, x = NULL, y, value = x) {
+      .Object@x <- list(value)
+      .Object@y <- y + 1
+      .Object
+    }
+  )
+  S4regVirtualChildInitialize := new_class(
+    parent = getClass("S4regVirtualInitialize"),
+    package = NULL
+  )
+
+  object <- S4regVirtualChildInitialize(x = 1, y = y)
+
+  expect_equal(object@x, list(1))
+  expect_equal(object@y, y + 1)
+  expect_identical(methods::validObject(object), TRUE)
+})
+
 test_that("S4 initialization sets S4 slots on subclasses of S7 classes", {
   on.exit(S4_remove_classes(c(
     "ParentForSlots",

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -464,7 +464,7 @@ test_that("S4_contains rejects properties with custom accessors", {
   expect_no_error(S4_register(S4regContainsDynamic))
   expect_error(
     S4_contains(S4regContainsDynamic),
-    "custom getter"
+    "custom getter or setter"
   )
   methods::setClass(
     "S4regContainsDynamicChild",
@@ -472,7 +472,7 @@ test_that("S4_contains rejects properties with custom accessors", {
   )
   expect_error(
     methods::new("S4regContainsDynamicChild"),
-    "custom getter"
+    "custom getter or setter"
   )
 
   S4regContainsSetter <- new_class(
@@ -491,7 +491,7 @@ test_that("S4_contains rejects properties with custom accessors", {
   expect_no_error(S4_register(S4regContainsSetter))
   expect_error(
     S4_contains(S4regContainsSetter),
-    "custom setter"
+    "custom getter or setter"
   )
   methods::setClass(
     "S4regContainsSetterChild",
@@ -499,7 +499,7 @@ test_that("S4_contains rejects properties with custom accessors", {
   )
   expect_error(
     methods::new("S4regContainsSetterChild"),
-    "custom setter"
+    "custom getter or setter"
   )
 })
 
@@ -761,6 +761,45 @@ test_that("S7 constructors dispatch to S4 parent initialize methods", {
   expect_identical(methods::validObject(object), TRUE)
 })
 
+test_that("S7 classes can not override S4 slots with custom accessors", {
+  defer(S4_remove_classes(c(
+    "S4regAccessorParent",
+    "S4regAccessorMiddle"
+  )))
+  setClass("S4regAccessorParent", slots = list(x = "numeric"))
+
+  expect_error(
+    new_class(
+      "S4regAccessorChild",
+      parent = getClass("S4regAccessorParent"),
+      properties = list(
+        x = new_property(class_numeric, getter = function(self) 1)
+      ),
+      package = NULL
+    ),
+    "custom getter or setter"
+  )
+
+  S4regAccessorMiddle := new_class(
+    parent = getClass("S4regAccessorParent"),
+    package = NULL
+  )
+  expect_error(
+    new_class(
+      "S4regAccessorChild",
+      parent = S4regAccessorMiddle,
+      properties = list(
+        x = new_property(
+          class_numeric,
+          setter = function(self, value) self
+        )
+      ),
+      package = NULL
+    ),
+    "custom getter or setter"
+  )
+})
+
 test_that("S4 initialization sets S4 slots on subclasses of S7 classes", {
   on.exit(S4_remove_classes(c(
     "ParentForSlots",
@@ -864,13 +903,13 @@ test_that("S4 classes can not extend S7-over-S4 classes with property setters", 
   expect_true(attr(Child2(x = 1, y = "a"), "setter_called", exact = TRUE))
   expect_error(
     S4_contains(Child2),
-    "custom setter"
+    "custom getter or setter"
   )
 
   methods::setClass("S4Child2", contains = "Child2")
   expect_error(
     methods::new("S4Child2"),
-    "custom setter"
+    "custom getter or setter"
   )
 })
 

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -299,6 +299,15 @@ test_that("new_object() gives useful error if called directly", {
   expect_snapshot(new_object(), error = TRUE)
 })
 
+test_that("new_object() can be forced lazily from a constructor", {
+  Foo := new_class(
+    constructor = function() identity(new_object(S7_object())),
+    package = NULL
+  )
+
+  expect_equal(S7_class(Foo()), Foo)
+})
+
 test_that("new_object() errors if `_parent` doesn't inherit from the parent class (#409)", {
   Bar := new_class(package = NULL)
   # `_parent` should be `Bar()`, not the class spec `Bar`

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -116,6 +116,47 @@ test_that("inheritance lets child properties narrow with S4 inheritance", {
   expect_s4_class(Child(x = x)@x, "S4PropertyChild")
 })
 
+test_that("inheritance lets S7 children narrow S4 parent properties", {
+  Animal := local_S4_class()
+  Kennel := local_S4_class(slots = list(dog = "Animal"))
+  Dog := new_class(parent = Animal, package = NULL)
+
+  DogKennel := new_class(
+    parent = Kennel,
+    properties = list(dog = Dog),
+    package = NULL
+  )
+  dog <- Dog()
+
+  expect_equal(prop(DogKennel(dog = dog), "dog"), dog)
+})
+
+test_that("inheritance lets S4 children narrow S7 parent properties", {
+  defer(S4_remove_classes(c(
+    "S4PropertyS7Parent",
+    "S4PropertyS7Child"
+  )))
+
+  S4PropertyS7Parent := new_class(package = NULL)
+  S4_register(S4PropertyS7Parent)
+  setClass(
+    "S4PropertyS7Child",
+    contains = S4_contains(S4PropertyS7Parent)
+  )
+  S4PropertyParent := new_class(
+    properties = list(x = S4PropertyS7Parent),
+    package = NULL
+  )
+  S4PropertyChild := new_class(
+    parent = S4PropertyParent,
+    properties = list(x = getClass("S4PropertyS7Child")),
+    package = NULL
+  )
+
+  x <- methods::new("S4PropertyS7Child")
+  expect_s4_class(S4PropertyChild(x = x)@x, "S4PropertyS7Child")
+})
+
 test_that("inheritance doesn't let child properties narrow S7_object with base or S3 classes", {
   Parent := new_class(
     properties = list(x = S7_object),

--- a/tests/testthat/test-method-register-S3.R
+++ b/tests/testthat/test-method-register-S3.R
@@ -86,6 +86,38 @@ test_that("internal generics register S4 methods for S4-backed S7 classes", {
   expect_equal(dim(object), c(1L, 2L))
 })
 
+test_that("base closures register S4 methods for S4-backed S7 classes", {
+  defer({
+    try(methods::removeMethod("unlist", "S4regUnlistChild"), silent = TRUE)
+    S4_remove_classes(c(
+      "S4regUnlistParent",
+      "S4regUnlistChild",
+      "S4regUnlistShim"
+    ))
+  })
+
+  setClass("S4regUnlistParent", contains = "VIRTUAL")
+  S4regUnlistChild := new_class(
+    parent = getClass("S4regUnlistParent"),
+    properties = list(x = class_integer),
+    package = NULL
+  )
+  method(unlist, S4regUnlistChild) <- function(
+    x,
+    recursive = TRUE,
+    use.names = TRUE
+  ) {
+    x@x
+  }
+  S4regUnlistChild_S4 <- S4_contains(S4regUnlistChild)
+  setClass("S4regUnlistShim", contains = S4regUnlistChild_S4)
+
+  object <- methods::new("S4regUnlistShim", x = 1L)
+
+  expect_equal(unlist(object), 1L)
+  expect_true(methods::hasMethod("unlist", "S4regUnlistChild"))
+})
+
 test_that("internal replacement generics can register full S4 signatures", {
   on.exit({
     try(


### PR DESCRIPTION
This PR addresses several high-priority compatibility issues found in #720:

- Registers S4 methods in the caller/package environment when S7 methods are registered for S4-derived classes on base/internal generics, fixing cases like `unlist()`.
- Allows generated constructors for S4 parents to route parent slot arguments through `methods::initialize()`. Parent slots were being dropped during construction.
  - Side fix: `new_object()` correctly detects its evaluation frame even when lazily evaluated as part of another call.
- Makes the `initialize()` method on S4-derived classes delegate to any non-default parent `initialize()` method, so as not to assume that the custom method has the same interface and semantics as the default method. When S4 is not extending S7, we could just not register our `initialize()` method when the default is overridden by a parent, but this seems like the simplest solution.
- Rejects S7 properties with custom getters or setters when they are overriding an S4 slot, since the slot layer will violate any encapsulation.
- Teaches `class_extends()` to correctly handle S4/S7 inheritance cases.