### PR TITLE
Make deferred generic resolution robust to upstream changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604).
 * `S7_inherits()` and `check_is_S7()` now accept any class specification (S7 class, S7 union, S3 class, S4 class, or base type wrapper like `class_integer`), not just S7 classes (#556).
 * `S7_on_load()` is the new name for `methods_register()`, giving it a nicer symmetry with `S7_on_build()`; `methods_register()` remains available for backward compatibility (#615). It no longer accumulates duplicate registration hooks when a package is loaded repeatedly (#316).
+* `S7_on_load()` no longer makes a package unloadable when a generic it registers a method for has been renamed or removed from the upstream package; it now warns and skips the registration. It also resolves generics through the upstream package's exports, so a generic can move to another package and be re-exported without breaking already-installed downstream packages (#729).
 * New `S7_on_unload()`, to be called from `.onUnload()`, unregisters active methods and removes hooks added by `S7_on_load()` (#316).
 * `set_props()` now names its first argument `_object` to minimise the chances of a clash with a property (#423). It also accepts a single unnamed named list as a shortcut for splicing property values, making it easier to set properties programmatically (#497).
 * `str()` on S7 objects that inherit from data.frame (or other S3 classes whose underlying data has a `dim` attribute incompatible with the bare base type) no longer errors (#494).

--- a/R/external-generic.R
+++ b/R/external-generic.R
@@ -135,8 +135,8 @@ external_methods_reset <- function(package) {
 
 
 resolve_generic <- function(generic) {
-  generic <- resolve_generic_opt(generic)
-  if (is.null(generic)) {
+  fun <- resolve_generic_opt(generic)
+  if (is.null(fun)) {
     warning(
       sprintf(
         "[S7] Failed to find generic %s() in package %s",
@@ -146,11 +146,16 @@ resolve_generic <- function(generic) {
       call. = FALSE
     )
   }
-  generic
+  fun
 }
+
 resolve_generic_opt <- function(generic) {
   ns <- asNamespace(generic$package)
-  get(generic$name, envir = ns, inherits = FALSE)
+  if (generic$name %in% getNamespaceExports(ns)) {
+    getExportedValue(generic$package, generic$name)
+  } else {
+    get0(generic$name, envir = ns, inherits = FALSE)
+  }
 }
 
 

--- a/tests/testthat/_snaps/external-generic.md
+++ b/tests/testthat/_snaps/external-generic.md
@@ -1,3 +1,11 @@
+# resolve_generic() warns instead of erroring when generic is missing
+
+    Code
+      out <- resolve_generic(gen)
+    Condition
+      Warning:
+      [S7] Failed to find generic gen() in package testpkg
+
 # displays nicely
 
     Code

--- a/tests/testthat/_snaps/hooks.md
+++ b/tests/testthat/_snaps/hooks.md
@@ -1,0 +1,8 @@
+# S7_on_load() warns instead of erroring when a generic no longer exists (#729)
+
+    Code
+      S7_on_load_(downstream)
+    Condition
+      Warning:
+      [S7] Failed to find generic gen() in package upstream
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -62,7 +62,10 @@ local_package <- function(
   version = "0.0.0",
   frame = parent.frame()
 ) {
-  ns <- new.env(parent = asNamespace("S7"))
+  # The intermediate environment plays the role of the imports environment
+  # of a real namespace, e.g. so tests can simulate re-exports.
+  imports <- new.env(parent = asNamespace("S7"))
+  ns <- new.env(parent = imports)
 
   info <- new.env(parent = emptyenv())
   info$spec <- c(name = name, version = version)

--- a/tests/testthat/test-external-generic.R
+++ b/tests/testthat/test-external-generic.R
@@ -45,6 +45,41 @@ test_that("can remove methods", {
   expect_length(S7_methods_table("testpkg"), 1)
 })
 
+test_that("resolve_generic_opt() finds re-exported generics", {
+  testcore := local_package({
+    gen := new_generic("x")
+  })
+
+  # Simulate testpkg re-exporting testcore::gen: the binding lives in the
+  # imports environment and is listed in the exports, but is absent from the
+  # namespace proper
+  testpkg := local_package()
+  assign("gen", testcore$gen, envir = parent.env(testpkg))
+  assign("gen", "gen", envir = testpkg[[".__NAMESPACE__."]]$exports)
+
+  gen := new_external_generic(package = "testpkg", dispatch_args = "x")
+  expect_identical(resolve_generic_opt(gen), testcore$gen)
+})
+
+test_that("resolve_generic_opt() finds unexported generics", {
+  testpkg := local_package({
+    gen := new_generic("x")
+  })
+  rm(list = "gen", envir = testpkg[[".__NAMESPACE__."]]$exports)
+
+  gen := new_external_generic(package = "testpkg", dispatch_args = "x")
+  expect_identical(resolve_generic_opt(gen), testpkg$gen)
+})
+
+test_that("resolve_generic() warns instead of erroring when generic is missing", {
+  testpkg := local_package()
+
+  gen := new_external_generic(package = "testpkg", dispatch_args = "x")
+  expect_null(resolve_generic_opt(gen))
+  expect_snapshot(out <- resolve_generic(gen))
+  expect_null(out)
+})
+
 test_that("displays nicely", {
   bar := new_external_generic("foo", dispatch_args = "x")
   expect_snapshot({

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -15,6 +15,18 @@ test_that("S7_on_load() doesn't accumulate hooks across repeated loads", {
   expect_length(package_hooks("upstream"), 1)
 })
 
+test_that("S7_on_load() warns instead of erroring when a generic no longer exists (#729)", {
+  upstream := local_package()
+  downstream := local_package()
+
+  # Simulate a stale install of downstream: its methods table records a
+  # generic that upstream has since renamed or removed
+  gen := new_external_generic(package = "upstream", dispatch_args = "x")
+  external_methods_add("downstream", gen, list(), function(x) x)
+
+  expect_snapshot(S7_on_load_(downstream))
+})
+
 test_that("S7_on_load() waits until all external union arms are available", {
   generic_pkg := local_package({
     gen := new_generic("x")


### PR DESCRIPTION
Fixes #729.

Two changes to `resolve_generic_opt()`:

* Use `get0()` instead of `get()`, so if the recorded generic no longer exists in the upstream package (e.g. it was renamed), resolution returns `NULL` and the registration hook emits the intended `[S7] Failed to find generic %s() in package %s` warning instead of erroring inside `.onLoad()`. (And make this warning actually work by not overriding `generic` with a possibly-NULL function.)

* It resolves through the upstream package's exports (via `getExportedValue()`), so a generic that has moved to another package and is re-exported is still found by already-installed downstream packages.

`local_package()` now gives its fake namespace an intermediate parent environment playing the role of the imports environment, so tests can simulate re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)