### PR TITLE
Check for a stored S7 class first in `has_S7_class()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@
 * `S7_data()` now preserves the S3 class when the S7 class inherits from an S3 class, so e.g. `S7_data()` on a data.frame subclass now returns a data.frame (#380).
 * `S7_data<-()` now preserves attributes (like `names` or `dim`) from the replacement data instead of carrying over the originals, so resizing the underlying data works correctly (#478).
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604).
+* `S7_inherits()` and `check_is_S7()` are 4.6x faster for instances of S7 classes, which are now detected by reading the stored class first rather than after two other tests (#723).
 * `S7_inherits()` and `check_is_S7()` now accept any class specification (S7 class, S7 union, S3 class, S4 class, or base type wrapper like `class_integer`), not just S7 classes (#556).
 * `S7_on_load()` is the new name for `methods_register()`, giving it a nicer symmetry with `S7_on_build()`; `methods_register()` remains available for backward compatibility (#615). It no longer accumulates duplicate registration hooks when a package is loaded repeatedly (#316).
 * `S7_on_load()` no longer makes a package unloadable when a generic it registers a method for has been renamed or removed from the upstream package; it now warns and skips the registration. It also resolves generics through the upstream package's exports, so a generic can move to another package and be re-exported without breaking already-installed downstream packages (#729).

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,6 @@
 * `S7_data()` now preserves the S3 class when the S7 class inherits from an S3 class, so e.g. `S7_data()` on a data.frame subclass now returns a data.frame (#380).
 * `S7_data<-()` now preserves attributes (like `names` or `dim`) from the replacement data instead of carrying over the originals, so resizing the underlying data works correctly (#478).
 * `S7_error_method_not_found` now has a correct class vector without a duplicate `"error"` entry (@jjjermiah, #604).
-* `S7_inherits()` and `check_is_S7()` are 4.6x faster for instances of S7 classes, which are now detected by reading the stored class first rather than after two other tests (#723).
 * `S7_inherits()` and `check_is_S7()` now accept any class specification (S7 class, S7 union, S3 class, S4 class, or base type wrapper like `class_integer`), not just S7 classes (#556).
 * `S7_on_load()` is the new name for `methods_register()`, giving it a nicer symmetry with `S7_on_build()`; `methods_register()` remains available for backward compatibility (#615). It no longer accumulates duplicate registration hooks when a package is loaded repeatedly (#316).
 * `S7_on_load()` no longer makes a package unloadable when a generic it registers a method for has been renamed or removed from the upstream package; it now warns and skips the registration. It also resolves generics through the upstream package's exports, so a generic can move to another package and be re-exported without breaking already-installed downstream packages (#729).

--- a/R/inherits.R
+++ b/R/inherits.R
@@ -47,9 +47,13 @@ S7_inherits <- function(x, class = NULL) {
 }
 
 has_S7_class <- function(x) {
-  identical(class(x), "S7_object") ||
-    inherits(x, "S7_class") ||
-    !is.null(.Call(S7_class_, x))
+  # Reading the stored class is the cheapest test and covers every instance of
+  # a user-defined class, so it goes first. The other two branches are still
+  # needed: bare `S7_object()` instances and class objects themselves don't
+  # store a class.
+  !is.null(.Call(S7_class_, x)) ||
+    identical(class(x), "S7_object") ||
+    inherits(x, "S7_class")
 }
 
 #' @export

--- a/R/inherits.R
+++ b/R/inherits.R
@@ -48,9 +48,7 @@ S7_inherits <- function(x, class = NULL) {
 
 has_S7_class <- function(x) {
   # Reading the stored class is the cheapest test and covers every instance of
-  # a user-defined class, so it goes first. The other two branches are still
-  # needed: bare `S7_object()` instances and class objects themselves don't
-  # store a class.
+  # a user-defined class, so it goes first.
   !is.null(.Call(S7_class_, x)) ||
     identical(class(x), "S7_object") ||
     inherits(x, "S7_class")

--- a/tests/testthat/test-inherits.R
+++ b/tests/testthat/test-inherits.R
@@ -9,6 +9,22 @@ test_that("it works", {
   expect_false(S7_inherits(1, NULL))
 })
 
+test_that("has_S7_class() recognises objects that don't store a class", {
+  foo := new_class()
+
+  # instances store their class, bare S7_object()s and classes don't
+  expect_all_true(c(
+    has_S7_class(foo()),
+    has_S7_class(S7_object()),
+    has_S7_class(foo),
+    has_S7_class(S7_object)
+  ))
+  expect_all_equal(
+    c(has_S7_class(1), has_S7_class(factor("a")), has_S7_class(NULL)),
+    FALSE
+  )
+})
+
 test_that("accepts any class specification (#556)", {
   # base
   expect_true(S7_inherits(1L, class_integer))

--- a/tests/testthat/test-inherits.R
+++ b/tests/testthat/test-inherits.R
@@ -12,17 +12,14 @@ test_that("it works", {
 test_that("has_S7_class() recognises objects that don't store a class", {
   foo := new_class()
 
-  # instances store their class, bare S7_object()s and classes don't
-  expect_all_true(c(
-    has_S7_class(foo()),
-    has_S7_class(S7_object()),
-    has_S7_class(foo),
-    has_S7_class(S7_object)
-  ))
-  expect_all_equal(
-    c(has_S7_class(1), has_S7_class(factor("a")), has_S7_class(NULL)),
-    FALSE
-  )
+  expect_true(has_S7_class(foo()))
+  expect_true(has_S7_class(S7_object()))
+  expect_true(has_S7_class(foo))
+  expect_true(has_S7_class(S7_object))
+
+  expect_false(has_S7_class(1))
+  expect_false(has_S7_class(factor("a")))
+  expect_false(has_S7_class(NULL))
 })
 
 test_that("accepts any class specification (#556)", {


### PR DESCRIPTION
Part of #723. 

This is a pretty small performance improvement: `has_S7_class()` 1.15 µs → **0.33 µs** (3.5x), but it's called in lots of places (`S7_inherits()`, `check_is_S7()`, `class_inherits()`, and the constructor's parent check) and it's a simple change.