### PR TITLE
Only validate base properties once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ There are three possible ways to run code, listed in rough order of desirability
 - Put all expressions being compared in a single `bench::mark()` call. `bench::mark()` interleaves and randomizes them so that thermal drift, background load, and garbage collection affect the expressions roughly equally.
 - Absolute timings can drift by ~10% between R sessions. So don't pursue changes smaller than this threshold.
 - Always benchmark both pre- and post-timings locally; don't assume timings posted in a GitHub issue are applicable to the current machine.
+- When reporting benchmark results, always include both the absolute pre- and post-timings and the relative change.
 - We care at most about microsecond scale. In the rare cases where they are important, batch 1000s of ns operations to get to around 1µs. On macOS, the timer used by `bench::mark()` has ~40 ns granularity.
 - Use `lobstr::obj_sizes()` to measure marginal memory usage when objects share references. Pass two equivalent objects to `obj_sizes()`: the first result includes the shared graph, while the second includes only the new object's contribution.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ There are three possible ways to run code, listed in rough order of desirability
 - Put all expressions being compared in a single `bench::mark()` call. `bench::mark()` interleaves and randomizes them so that thermal drift, background load, and garbage collection affect the expressions roughly equally.
 - Absolute timings can drift by ~10% between R sessions. So don't pursue changes smaller than this threshold.
 - Always benchmark both pre- and post-timings locally; don't assume timings posted in a GitHub issue are applicable to the current machine.
-- When reporting benchmark results, always include both the absolute pre- and post-timings and the relative change.
+- When reporting benchmark results, always include both the absolute pre- and post-timings and the relative change as "x faster", not as a percentage reduction in time. Round timings to two significant digits (e.g. 100 µs, not 100.2 µs; 70 µs, not 69.4 µs).
 - We care at most about microsecond scale. In the rare cases where they are important, batch 1000s of ns operations to get to around 1µs. On macOS, the timer used by `bench::mark()` has ~40 ns granularity.
 - Use `lobstr::obj_sizes()` to measure marginal memory usage when objects share references. Pass two equivalent objects to `obj_sizes()`: the first result includes the shared graph, while the second includes only the new object's contribution.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@
 * `set_props()` now names its first argument `_object` to minimise the chances of a clash with a property (#423). It also accepts a single unnamed named list as a shortcut for splicing property values, making it easier to set properties programmatically (#497).
 * `str()` on S7 objects that inherit from data.frame (or other S3 classes whose underlying data has a `dim` attribute incompatible with the bare base type) no longer errors (#494).
 * `super()` now works with S3 and S4 objects, not just S7 objects (#500).
+* `validate()` now checks property types substantially faster, because a property restricted to a base type (e.g. `class_double`) no longer has its underlying type checked twice. Constructing an object with 50 base type properties is 1.6x faster, and with 10 base type properties 1.4x faster (#723).
 * `validate()` now signals validation errors with class `S7_error_validation_failed`, so they can be caught with `tryCatch()` (#602, #605).
 
 # S7 0.2.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,7 +57,7 @@
 * `set_props()` now names its first argument `_object` to minimise the chances of a clash with a property (#423). It also accepts a single unnamed named list as a shortcut for splicing property values, making it easier to set properties programmatically (#497).
 * `str()` on S7 objects that inherit from data.frame (or other S3 classes whose underlying data has a `dim` attribute incompatible with the bare base type) no longer errors (#494).
 * `super()` now works with S3 and S4 objects, not just S7 objects (#500).
-* `validate()` now checks property types substantially faster, because a property restricted to a base type (e.g. `class_double`) no longer has its underlying type checked twice. Constructing an object with 10 base type properties fell from 100.2 µs to 69.4 µs (31% less time; 1.4x faster), while constructing one with 50 fell from 404.0 µs to 250.9 µs (38% less time; 1.6x faster) (#723).
+* `validate()` now checks property types substantially faster, because a property restricted to a base type (e.g. `class_double`) no longer has its underlying type checked twice. Constructing an object with 10 base type properties fell from 100 µs to 70 µs (1.4x faster), while constructing one with 50 fell from 400 µs to 250 µs (1.6x faster) (#723).
 * `validate()` now signals validation errors with class `S7_error_validation_failed`, so they can be caught with `tryCatch()` (#602, #605).
 
 # S7 0.2.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,7 +57,7 @@
 * `set_props()` now names its first argument `_object` to minimise the chances of a clash with a property (#423). It also accepts a single unnamed named list as a shortcut for splicing property values, making it easier to set properties programmatically (#497).
 * `str()` on S7 objects that inherit from data.frame (or other S3 classes whose underlying data has a `dim` attribute incompatible with the bare base type) no longer errors (#494).
 * `super()` now works with S3 and S4 objects, not just S7 objects (#500).
-* `validate()` now checks property types substantially faster, because a property restricted to a base type (e.g. `class_double`) no longer has its underlying type checked twice. Constructing an object with 50 base type properties is 1.6x faster, and with 10 base type properties 1.4x faster (#723).
+* `validate()` now checks property types substantially faster, because a property restricted to a base type (e.g. `class_double`) no longer has its underlying type checked twice. Constructing an object with 10 base type properties fell from 100.2 µs to 69.4 µs (31% less time; 1.4x faster), while constructing one with 50 fell from 404.0 µs to 250.9 µs (38% less time; 1.6x faster) (#723).
 * `validate()` now signals validation errors with class `S7_error_validation_failed`, so they can be caught with `tryCatch()` (#602, #605).
 
 # S7 0.2.2

--- a/R/property.R
+++ b/R/property.R
@@ -304,18 +304,24 @@ signal_setter_error <- function(value, object, name) {
 
 # called from src/prop.c
 prop_validate <- function(prop, value, object = NULL) {
-  if (!class_inherits(value, prop$class)) {
+  class <- prop$class
+
+  if (!class_inherits(value, class)) {
     return(sprintf(
       "%s must be %s, not %s",
       prop_label(object, prop$name),
-      class_desc(prop$class),
+      class_desc(class),
       obj_desc(value)
     ))
   }
 
-  class_error <- class_validate(prop$class, value)
-  if (length(class_error) > 0) {
-    return(paste0(prop_label(object, prop$name), ": ", class_error))
+  # A base class's validator does nothing but re-check the underlying type,
+  # which `class_inherits()` has just done.
+  if (!is_base_class(class)) {
+    class_error <- class_validate(class, value)
+    if (length(class_error) > 0) {
+      return(paste0(prop_label(object, prop$name), ": ", class_error))
+    }
   }
 
   if (is.null(validator <- prop$validator)) {

--- a/R/valid.R
+++ b/R/valid.R
@@ -176,18 +176,12 @@ validate_properties <- function(object, class, parent_class = NULL) {
 
     value <- prop(object, name)
 
-    # The common case: a base type property, already the right type, with no
-    # validator of its own. Nothing for prop_validate() to find.
-    prop_class <- prop_obj$class
-    if (
-      is_base_class(prop_class) &&
-        is.null(prop_obj$validator) &&
-        prop_class$class == base_class(value)
-    ) {
+    err <- prop_validate(prop_obj, value)
+    if (is.null(err)) {
       next
     }
 
-    errors <- c(errors, prop_validate(prop_obj, value))
+    errors <- c(errors, err)
   }
 
   errors

--- a/R/valid.R
+++ b/R/valid.R
@@ -152,23 +152,41 @@ validate_from <- function(
 }
 
 validate_properties <- function(object, class, parent_class = NULL) {
-  errors <- character()
+  props <- attr(class, "properties", TRUE)
+  if (length(props) == 0) {
+    return(character())
+  }
+
   # runs on every construction
   parent_props <- if (is_class(parent_class)) {
     attr(parent_class, "properties", TRUE)
   }
+  errors <- character()
 
-  for (prop_obj in attr(class, "properties", TRUE)) {
+  for (prop_obj in props) {
     # Don't validate dynamic properties
     if (!is.null(prop_obj$getter)) {
       next
     }
+    name <- prop_obj$name
     # Skip properties inherited unchanged from an already-validated parent
-    if (identical(parent_props[[prop_obj$name]], prop_obj)) {
+    if (!is.null(parent_props) && identical(parent_props[[name]], prop_obj)) {
       next
     }
 
-    value <- prop(object, prop_obj$name)
+    value <- prop(object, name)
+
+    # The common case: a base type property, already the right type, with no
+    # validator of its own. Nothing for prop_validate() to find.
+    prop_class <- prop_obj$class
+    if (
+      is_base_class(prop_class) &&
+        is.null(prop_obj$validator) &&
+        prop_class$class == base_class(value)
+    ) {
+      next
+    }
+
     errors <- c(errors, prop_validate(prop_obj, value))
   }
 

--- a/tests/testthat/_snaps/valid.md
+++ b/tests/testthat/_snaps/valid.md
@@ -45,6 +45,25 @@
       ! <Double> object is invalid:
       - Underlying data must be <double> not <character>
 
+# validate runs property validators for base type properties
+
+    Code
+      Positive(x = -1)
+    Condition
+      Error in `Positive()`:
+      ! <Positive> object properties are invalid:
+      - @x must be positive
+
+# validate runs class validators for non-base type properties
+
+    Code
+      validate(obj)
+    Condition
+      Error in `validate()`:
+      ! <Wrapper> object properties are invalid:
+      - @x: attr(, 'levels') must be a <character>
+      - @x: Not enough 'levels' for underlying data
+
 # validate checks the type of setters
 
     Code

--- a/tests/testthat/test-valid.R
+++ b/tests/testthat/test-valid.R
@@ -50,6 +50,27 @@ test_that("validate checks base type", {
   expect_snapshot(error = TRUE, validate(x))
 })
 
+test_that("validate runs property validators for base type properties", {
+  Positive := new_class(
+    package = NULL,
+    properties = list(
+      x = new_property(
+        class_double,
+        validator = function(value) if (value < 0) "must be positive"
+      )
+    )
+  )
+  expect_snapshot(error = TRUE, Positive(x = -1))
+})
+
+test_that("validate runs class validators for non-base type properties", {
+  Wrapper := new_class(package = NULL, properties = list(x = class_factor))
+  obj <- Wrapper(x = factor("a"))
+  attr(obj, "x") <- structure(1L, class = "factor")
+
+  expect_snapshot(error = TRUE, validate(obj))
+})
+
 test_that("validate checks the type of setters", {
   foo := new_class(
     package = NULL,


### PR DESCRIPTION
Part of #723. Rebased onto current `main`.

For a property restricted to a base type, `prop_validate()` called `class_inherits()` to check the underlying type and then called the base class validator, which checked exactly the same thing again. This is a reasonable hot path since we expect that many properties will be base classes.

## Benchmarks

I benchmarked current `main` (`91f41404`) and this PR locally back-to-back using `bench/constructor.R`, with all comparable expressions in a single randomized `bench::mark()` call.

| Case | Before | After | Change |
|---|---:|---:|---:|
| 2 base-type properties | 40 µs | 34 µs | 1.2x faster |
| 10 base-type properties | 100 µs | 70 µs | 1.4x faster |
| 50 base-type properties | 400 µs | 250 µs | 1.6x faster |

Hierarchy construction, zero-property construction, and standalone validation were within the ~10% between-session drift threshold.