### PR TITLE
Cache construction metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@
 * `set_props()` now names its first argument `_object` to minimise the chances of a clash with a property (#423). It also accepts a single unnamed named list as a shortcut for splicing property values, making it easier to set properties programmatically (#497).
 * `str()` on S7 objects that inherit from data.frame (or other S3 classes whose underlying data has a `dim` attribute incompatible with the bare base type) no longer errors (#494).
 * `super()` now works with S3 and S4 objects, not just S7 objects (#500).
+* `validate()` now checks property types substantially faster, because a property restricted to a base type (e.g. `class_double`) no longer has its underlying type checked twice. Constructing an object with 50 base type properties is 1.6x faster, and with 10 base type properties 1.4x faster (#723).
 * `validate()` now signals validation errors with class `S7_error_validation_failed`, so they can be caught with `tryCatch()` (#602, #605).
 
 # S7 0.2.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * `method<-` now gives a clear error when assigning a primitive function (e.g. `log`) as a method (#608).
 * `method<-` and `method()` now accept a length-1 list as `signature` for single-dispatch generics, matching the list-of-classes form required for multi-dispatch (#555).
 * `new_object()` now names its first argument `_parent` to minimise the chance of a clash with a property (#423). It also accepts a single unnamed named list as a shortcut for splicing property values, making it easier to programmatically construct an object from a list of properties (#497).
+* `new_object()` no longer copies an S7 class each time a default or custom constructor creates an object. New objects instead store a shared internal class reference, which also preserves sharing when multiple objects are serialised together. Constructors created by older versions of S7 continue to work through the previous fallback (#742).
 * `method<-` can now register methods on S3 and S4 generics with base types (e.g. `class_character`), S3 classes (`new_S3_class()`, `class_factor`, etc.), S7 unions (expanded to one registration per class), `class_any` (registered as the `default` method), and `NULL` (registered as the `NULL` method) (#455).
 * `method<-` no longer emits an "Overwriting method" message when re-registering an identical method, eliminating spurious messages from `devtools::load_all()` (#474).
 * `new_class()` now errors if a child class overrides a parent property with a type that doesn't extend the parent's type, since such a class could never be instantiated (#352, #708).

--- a/R/class.R
+++ b/R/class.R
@@ -201,6 +201,12 @@ new_class <- function(
   attr(object, "S7_dispatch") <- S7_class_dispatch(class_name, parent_resolved)
   class(object) <- c("S7_class", "S7_object")
   class_ref$class <- object
+  class_ref$construction <- new_construction_metadata(
+    parent = parent_resolved,
+    properties = all_props,
+    new_properties = new_props,
+    validator = validator
+  )
 
   if (S7_extends_S4(object)) {
     S4_register_subclass(object, env = parent.frame())
@@ -208,6 +214,72 @@ new_class <- function(
 
   global_variables(names(all_props))
   object
+}
+
+new_construction_metadata <- function(
+  parent,
+  properties,
+  new_properties,
+  validator
+) {
+  stored <- properties[vlapply(properties, \(x) is.null(x$getter))]
+  setter_names <- names(properties)[vlapply(properties, prop_has_setter)]
+  storage_names <- prop_storage_names_r(names(properties))
+  stored_storage_names <- prop_storage_names_r(names(stored))
+
+  base_types <- lapply(stored, function(prop) {
+    if (is_base_class(prop$class) && is.null(prop$validator)) {
+      prop$class$class
+    } else {
+      NULL
+    }
+  })
+
+  list(
+    setter_names = setter_names,
+    storage_names = setNames(storage_names, names(properties)),
+    parent_property_names = names(class_properties(parent)),
+    validation_properties = stored,
+    validation_storage_names = stored_storage_names,
+    validation_base_types = base_types,
+    direct_property_access = !is_S4_class(parent) &&
+      !(is_class(parent) && S7_extends_S4(parent)),
+    validates_nothing = length(new_properties) == 0 &&
+      is.null(validator)
+  )
+}
+
+prop_storage_names_r <- function(names) {
+  special <- c(
+    names = "_names",
+    dim = "_dim",
+    dimnames = "_dimnames",
+    class = "_class",
+    tsp = "_tsp",
+    comment = "_comment",
+    row.names = "_row_names"
+  )
+  replace <- match(names, names(special), nomatch = 0L)
+  names[replace > 0L] <- unname(special[replace])
+  names
+}
+
+class_construction_metadata <- function(class) {
+  class_storage <- S7_class_storage(class)
+  metadata <- if (inherits(class_storage, "S7_class_ref")) {
+    class_storage$construction
+  }
+  if (!is.null(metadata)) {
+    return(metadata)
+  }
+
+  properties <- attr(class, "properties", TRUE)
+  new_construction_metadata(
+    parent = attr(class, "parent", TRUE),
+    properties = properties,
+    new_properties = properties,
+    validator = attr(class, "validator", TRUE)
+  )
 }
 globalVariables(c(
   "name",
@@ -410,8 +482,8 @@ new_object <- function(`_parent`, ...) {
   # This is the hottest function in S7, so read the class metadata we need once,
   # up front.
   class_abstract <- attr(class, "abstract", TRUE)
-  class_props <- attr(class, "properties", TRUE)
   class_parent <- attr(class, "parent", TRUE)
+  metadata <- class_construction_metadata(class)
 
   if (class_abstract && !is_constructing_parent_part(class)) {
     msg <- sprintf(
@@ -428,9 +500,9 @@ new_object <- function(`_parent`, ...) {
 
   args <- collect_dots(...)
 
-  has_setter <- vlapply(class_props[names(args)], prop_has_setter)
+  has_setter <- names(args) %in% metadata$setter_names
   self_attrs <- args[!has_setter]
-  names(self_attrs) <- prop_storage_rename(names(self_attrs))
+  names(self_attrs) <- metadata$storage_names[names(self_attrs)]
 
   # We must awkwardly operate on `_parent` rather than binding to a local
   # variable; since otherwise the extra binding causes ALTREP-wrapped values to
@@ -458,15 +530,19 @@ new_object <- function(`_parent`, ...) {
     inherits(class_parent, "S7_object") &&
     !attr(class_parent, "abstract", TRUE)
   parent_props_reset <- parent_validated &&
-    any(
-      names2(args) %in% names2(attr(class_parent, "properties", TRUE))
+    any(names2(args) %in% metadata$parent_property_names)
+  if (
+    !metadata$validates_nothing ||
+      !parent_validated ||
+      parent_props_reset
+  ) {
+    validate_from(
+      `_parent`,
+      parent = if (parent_validated && !parent_props_reset) class_parent,
+      # Attribute validation failures to the constructor call, not new_object()
+      call = sys.call(-1L)
     )
-  validate_from(
-    `_parent`,
-    parent = if (parent_validated && !parent_props_reset) class_parent,
-    # Attribute validation failures to the constructor call, not new_object()
-    call = sys.call(-1L)
-  )
+  }
 
   `_parent`
 }

--- a/R/class.R
+++ b/R/class.R
@@ -34,8 +34,10 @@
 #'   argument for each property.
 #'
 #'   A custom constructor should call `new_object()` to create the S7 object.
-#'   The first argument, `.data`, should be an instance of the parent class
-#'   (if used). The subsequent arguments are used to set the properties.
+#'   `new_class()` automatically associates a custom constructor with its class,
+#'   so no additional class argument is needed. The first argument to
+#'   `new_object()`, `_parent`, should be an instance of the parent class (if
+#'   used). The subsequent arguments are used to set the properties.
 #' @param validator A function taking a single argument, `self`, the object
 #'   to validate.
 #'
@@ -174,6 +176,12 @@ new_class <- function(
     )
   }
 
+  class_ref <- new.env(parent = emptyenv())
+  class(class_ref) <- "S7_class_ref"
+  constructor_env <- new.env(parent = environment(constructor))
+  constructor_env$.S7_class_ref <- class_ref
+  environment(constructor) <- constructor_env
+
   object <- constructor
   # A class's metadata is stored as plain attributes on the class object.
   # Must synchronise with prop_names().
@@ -192,6 +200,7 @@ new_class <- function(
   attr(object, "S7_class_name") <- class_name
   attr(object, "S7_dispatch") <- S7_class_dispatch(class_name, parent_resolved)
   class(object) <- c("S7_class", "S7_object")
+  class_ref$class <- object
 
   if (S7_extends_S4(object)) {
     S4_register_subclass(object, env = parent.frame())
@@ -384,7 +393,17 @@ check_parent <- function(parent, class, call = sys.call(-1L)) {
 #' @rdname new_class
 #' @export
 new_object <- function(`_parent`, ...) {
-  class <- sys.function(sys.parent())
+  class_ref <- get0(
+    ".S7_class_ref",
+    envir = parent.frame(),
+    inherits = TRUE,
+    ifnotfound = NULL
+  )
+  if (inherits(class_ref, "S7_class_ref")) {
+    class <- class_ref$class
+  } else {
+    class <- sys.function(sys.parent())
+  }
   if (!inherits(class, "S7_class")) {
     stop2("`new_object()` must be called from within a constructor.")
   }
@@ -417,7 +436,10 @@ new_object <- function(`_parent`, ...) {
   # variable; since otherwise the extra binding causes ALTREP-wrapped values to
   # be materialised when byte-compiled (#607).
   attrs <- c(
-    list(class = class_dispatch(class), `_S7_class` = class),
+    list(
+      class = class_dispatch(class),
+      `_S7_class` = if (S7_extends_S4(class)) class else class_ref %||% class
+    ),
     self_attrs,
     attributes(`_parent`)
   )
@@ -511,6 +533,15 @@ S7_class <- function(object) {
     },
     S3 = new_S3_class(class(object)),
     base = base_S7_class(object)
+  )
+}
+
+S7_class_storage <- function(class) {
+  get0(
+    ".S7_class_ref",
+    envir = environment(class),
+    inherits = TRUE,
+    ifnotfound = class
   )
 }
 

--- a/R/convert.R
+++ b/R/convert.R
@@ -229,7 +229,7 @@ convert_up <- function(from, to, call = sys.call(-1L)) {
     }
 
     from <- zap_attr(from, c(setdiff(from_props, to_props), "S7_class"))
-    attr(from, "_S7_class") <- to
+    attr(from, "_S7_class") <- if (isS4(from)) to else S7_class_storage(to)
     class(from) <- class_dispatch(to)
   } else if (is_S4_coerce(from, to)) {
     from <- convert_S4(from, to)

--- a/R/property.R
+++ b/R/property.R
@@ -304,18 +304,24 @@ signal_setter_error <- function(value, object, name) {
 
 # called from src/prop.c
 prop_validate <- function(prop, value, object = NULL) {
-  if (!class_inherits(value, prop$class)) {
+  class <- prop$class
+
+  if (!class_inherits(value, class)) {
     return(sprintf(
       "%s must be %s, not %s",
       prop_label(object, prop$name),
-      class_desc(prop$class),
+      class_desc(class),
       obj_desc(value)
     ))
   }
 
-  class_error <- class_validate(prop$class, value)
-  if (length(class_error) > 0) {
-    return(paste0(prop_label(object, prop$name), ": ", class_error))
+  # A base class's validator does nothing but re-check the underlying type,
+  # which `class_inherits()` has just done.
+  if (!is_base_class(class)) {
+    class_error <- class_validate(class, value)
+    if (length(class_error) > 0) {
+      return(paste0(prop_label(object, prop$name), ": ", class_error))
+    }
   }
 
   if (is.null(validator <- prop$validator)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,6 +12,10 @@ global_variables <- function(names) {
   assign(".__global__", current, envir = env)
 }
 
+obj_addr <- function(x) {
+  .Call(obj_addr_, x)
+}
+
 vlapply <- function(X, FUN, ...) {
   vapply(X = X, FUN = FUN, FUN.VALUE = logical(1), ...)
 }

--- a/R/valid.R
+++ b/R/valid.R
@@ -152,7 +152,8 @@ validate_from <- function(
 }
 
 validate_properties <- function(object, class, parent_class = NULL) {
-  props <- attr(class, "properties", TRUE)
+  metadata <- class_construction_metadata(class)
+  props <- metadata$validation_properties
   if (length(props) == 0) {
     return(character())
   }
@@ -163,27 +164,24 @@ validate_properties <- function(object, class, parent_class = NULL) {
   }
   errors <- character()
 
-  for (prop_obj in props) {
-    # Don't validate dynamic properties
-    if (!is.null(prop_obj$getter)) {
-      next
-    }
+  for (i in seq_along(props)) {
+    prop_obj <- props[[i]]
     name <- prop_obj$name
     # Skip properties inherited unchanged from an already-validated parent
     if (!is.null(parent_props) && identical(parent_props[[name]], prop_obj)) {
       next
     }
 
-    value <- prop(object, name)
+    value <- if (metadata$direct_property_access && !isS4(object)) {
+      attr(object, metadata$validation_storage_names[[i]], exact = TRUE)
+    } else {
+      prop(object, name)
+    }
 
     # The common case: a base type property, already the right type, with no
     # validator of its own. Nothing for prop_validate() to find.
-    prop_class <- prop_obj$class
-    if (
-      is_base_class(prop_class) &&
-        is.null(prop_obj$validator) &&
-        prop_class$class == base_class(value)
-    ) {
+    base_type <- metadata$validation_base_types[[i]]
+    if (!is.null(base_type) && base_type == base_class(value)) {
       next
     }
 

--- a/R/valid.R
+++ b/R/valid.R
@@ -152,23 +152,41 @@ validate_from <- function(
 }
 
 validate_properties <- function(object, class, parent_class = NULL) {
-  errors <- character()
+  props <- attr(class, "properties", TRUE)
+  if (length(props) == 0) {
+    return(character())
+  }
+
   # runs on every construction
   parent_props <- if (is_class(parent_class)) {
     attr(parent_class, "properties", TRUE)
   }
+  errors <- character()
 
-  for (prop_obj in attr(class, "properties", TRUE)) {
+  for (prop_obj in props) {
     # Don't validate dynamic properties
     if (!is.null(prop_obj$getter)) {
       next
     }
+    name <- prop_obj$name
     # Skip properties inherited unchanged from an already-validated parent
-    if (identical(parent_props[[prop_obj$name]], prop_obj)) {
+    if (!is.null(parent_props) && identical(parent_props[[name]], prop_obj)) {
       next
     }
 
-    value <- prop(object, prop_obj$name)
+    value <- prop(object, name)
+
+    # The common case: a base type property, already the right type, with no
+    # validator of its own. Nothing for prop_validate() to find.
+    prop_class <- prop_obj$class
+    if (
+      is_base_class(prop_class) &&
+        is.null(prop_obj$validator) &&
+        prop_class$class == base_class(value)
+    ) {
+      next
+    }
+
     errors <- c(errors, prop_validate(prop_obj, value))
   }
 

--- a/man/new_class.Rd
+++ b/man/new_class.Rd
@@ -55,8 +55,10 @@ on the default constructor, which will generate a function with one
 argument for each property.
 
 A custom constructor should call \code{new_object()} to create the S7 object.
-The first argument, \code{.data}, should be an instance of the parent class
-(if used). The subsequent arguments are used to set the properties.}
+\code{new_class()} automatically associates a custom constructor with its class,
+so no additional class argument is needed. The first argument to
+\code{new_object()}, \verb{_parent}, should be an instance of the parent class (if
+used). The subsequent arguments are used to set the properties.}
 
 \item{validator}{A function taking a single argument, \code{self}, the object
 to validate.

--- a/src/init.c
+++ b/src/init.c
@@ -13,6 +13,7 @@ extern SEXP prop_set_(SEXP, SEXP, SEXP, SEXP);
 extern SEXP prop_storage_rename_(SEXP);
 extern SEXP S7_eval_bare_(SEXP, SEXP);
 extern SEXP class_type_(SEXP);
+extern SEXP obj_addr_(SEXP);
 extern void prop_init(void);
 extern void class_type_init(void);
 
@@ -27,6 +28,7 @@ static const R_CallMethodDef CallEntries[] = {
     CALLDEF(prop_storage_rename_, 1),
     CALLDEF(S7_eval_bare_, 2),
     CALLDEF(class_type_, 1),
+    CALLDEF(obj_addr_, 1),
     {NULL, NULL, 0}
 };
 
@@ -38,6 +40,7 @@ static const R_ExternalMethodDef ExternalEntries[] = {
 SEXP sym_ANY;
 SEXP sym_S7_class;
 SEXP sym_S7_class_legacy;
+SEXP sym_class;
 
 SEXP sym_name;
 SEXP sym_parent;
@@ -102,6 +105,7 @@ void R_init_S7(DllInfo *dll)
     sym_S7_class = Rf_install("_S7_class");
     // Legacy name used by objects created with an older version of S7.
     sym_S7_class_legacy = Rf_install("S7_class");
+    sym_class = Rf_install("class");
     sym_name = Rf_install("name");
     sym_parent = Rf_install("parent");
     sym_package = Rf_install("package");

--- a/src/prop.c
+++ b/src/prop.c
@@ -1,8 +1,10 @@
 #include "compat.h"
+#include <stdio.h>
 #include <string.h>
 
 extern SEXP sym_S7_class;
 extern SEXP sym_S7_class_legacy;
+extern SEXP sym_class;
 
 extern SEXP sym_name;
 extern SEXP sym_parent;
@@ -40,12 +42,20 @@ SEXP get_S7_class(SEXP object) {
   SEXP S7_class = Rf_getAttrib(object, sym_S7_class);
   if (S7_class == R_NilValue)
     S7_class = Rf_getAttrib(object, sym_S7_class_legacy);
+  if (TYPEOF(S7_class) == ENVSXP && Rf_inherits(S7_class, "S7_class_ref"))
+    S7_class = s7_get_var_in_frame(S7_class, sym_class, R_NilValue);
   return S7_class;
 }
 
 // R-callable wrapper around get_S7_class().
 SEXP S7_class_(SEXP object) {
   return get_S7_class(object);
+}
+
+SEXP obj_addr_(SEXP object) {
+  char address[2 * sizeof(void *) + 3];
+  snprintf(address, sizeof(address), "%p", (void *) object);
+  return Rf_mkString(address);
 }
 
 static inline

--- a/tests/testthat/_snaps/valid.md
+++ b/tests/testthat/_snaps/valid.md
@@ -45,6 +45,25 @@
       ! <Double> object is invalid:
       - Underlying data must be <double> not <character>
 
+# validate runs property validators for base type properties
+
+    Code
+      Positive(x = -1)
+    Condition
+      Error in `Positive()`:
+      ! <Positive> object properties are invalid:
+      - @x must be positive
+
+# validate runs class validators for non-base type properties
+
+    Code
+      validate(obj)
+    Condition
+      Error in `validate()`:
+      ! <Wrapper> object properties are invalid:
+      - @x: attr(, 'levels') must be a <character>
+      - @x: Not enough 'levels' for underlying data
+
 # validate checks the type of setters
 
     Code

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -363,6 +363,87 @@ test_that("new_object() gives useful error if called directly", {
   expect_snapshot(new_object(), error = TRUE)
 })
 
+test_that("new_object() stores a shared class reference (#742)", {
+  Foo := new_class(package = NULL)
+  x <- Foo()
+  y <- Foo()
+
+  x_ref <- attr(x, "_S7_class", exact = TRUE)
+  y_ref <- attr(y, "_S7_class", exact = TRUE)
+  expect_type(x_ref, "environment")
+  expect_equal(obj_addr(x_ref), obj_addr(y_ref))
+  expect_equal(obj_addr(S7_class(x)), obj_addr(Foo))
+  expect_equal(obj_addr(S7_class(y)), obj_addr(Foo))
+})
+
+test_that("custom constructors use a shared class reference (#742)", {
+  Foo := new_class(
+    constructor = function(x) new_object(S7_object(), x = x),
+    properties = list(x = class_double),
+    package = NULL
+  )
+
+  x <- Foo(1)
+  y <- Foo(2)
+  expect_equal(
+    obj_addr(attr(x, "_S7_class", exact = TRUE)),
+    obj_addr(attr(y, "_S7_class", exact = TRUE))
+  )
+  expect_equal(obj_addr(S7_class(x)), obj_addr(Foo))
+  expect_equal(obj_addr(S7_class(y)), obj_addr(Foo))
+})
+
+test_that("serialisation preserves shared class references (#742)", {
+  Foo := new_class(package = NULL)
+  xy <- unserialize(serialize(list(Foo(), Foo()), NULL))
+
+  expect_equal(
+    obj_addr(attr(xy[[1]], "_S7_class", exact = TRUE)),
+    obj_addr(attr(xy[[2]], "_S7_class", exact = TRUE))
+  )
+  expect_equal(
+    obj_addr(S7_class(xy[[1]])),
+    obj_addr(S7_class(xy[[2]]))
+  )
+
+  Foo_rds <- unserialize(serialize(Foo, NULL))
+  x <- Foo_rds()
+  y <- Foo_rds()
+  expect_equal(
+    obj_addr(attr(x, "_S7_class", exact = TRUE)),
+    obj_addr(attr(y, "_S7_class", exact = TRUE))
+  )
+  expect_equal(
+    obj_addr(S7_class(x)),
+    obj_addr(S7_class(y))
+  )
+})
+
+test_that("classes in namespaces use shared class references (#742)", {
+  pkg := local_package({
+    Foo := new_class()
+  })
+  Foo <- pkg$Foo
+  x <- Foo()
+  y <- Foo()
+
+  expect_equal(
+    obj_addr(attr(x, "_S7_class", exact = TRUE)),
+    obj_addr(attr(y, "_S7_class", exact = TRUE))
+  )
+  expect_equal(obj_addr(S7_class(x)), obj_addr(Foo))
+  expect_equal(obj_addr(S7_class(y)), obj_addr(Foo))
+})
+
+test_that("new_object() supports constructors without a class reference", {
+  Foo := new_class(package = NULL)
+  environment(Foo) <- parent.env(environment(Foo))
+
+  x <- Foo()
+  expect_type(attr(x, "_S7_class", exact = TRUE), "closure")
+  expect_equal(S7_class(x), Foo)
+})
+
 test_that("new_object() can be forced lazily from a constructor", {
   Foo := new_class(
     constructor = function() identity(new_object(S7_object())),

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -15,6 +15,31 @@ test_that("S7 classes possess expected properties", {
   expect_type(foo@properties, "list")
 })
 
+test_that("classes cache construction metadata", {
+  Parent := new_class(
+    properties = list(x = class_double)
+  )
+  Child := new_class(
+    parent = Parent,
+    properties = list(
+      names = class_character,
+      computed = new_property(
+        getter = \(self) self@x
+      )
+    )
+  )
+
+  metadata <- class_construction_metadata(Child)
+  expect_equal(metadata$storage_names[["names"]], "_names")
+  expect_named(metadata$validation_properties, c("x", "names"))
+  expect_equal(
+    metadata$validation_base_types,
+    list(x = "double", names = "character")
+  )
+  expect_equal(metadata$parent_property_names, "x")
+  expect_identical(metadata$validates_nothing, FALSE)
+})
+
 test_that("S7 classes print nicely", {
   foo1 := new_class(
     properties = list(x = class_integer, y = class_integer),

--- a/tests/testthat/test-valid.R
+++ b/tests/testthat/test-valid.R
@@ -50,6 +50,27 @@ test_that("validate checks base type", {
   expect_snapshot(error = TRUE, validate(x))
 })
 
+test_that("validate runs property validators for base type properties", {
+  Positive := new_class(
+    package = NULL,
+    properties = list(
+      x = new_property(
+        class_double,
+        validator = function(value) if (value < 0) "must be positive"
+      )
+    )
+  )
+  expect_snapshot(error = TRUE, Positive(x = -1))
+})
+
+test_that("validate runs class validators for non-base type properties", {
+  Wrapper := new_class(package = NULL, properties = list(x = class_factor))
+  obj <- Wrapper(x = factor("a"))
+  attr(obj, "x") <- structure(1L, class = "factor")
+
+  expect_snapshot(error = TRUE, validate(obj))
+})
+
 test_that("validate checks the type of setters", {
   foo := new_class(
     package = NULL,


### PR DESCRIPTION
Prototype for #723.

This is stacked on the functional commits from #737 and #743 and should be rebased once those PRs land.

Classes cache construction metadata in the environment-backed class reference introduced by #743:

- property names with setters
- property storage names
- parent property names
- stored properties requiring validation
- expected base types
- whether a class layer adds any validation work

`new_object()` uses the cache to avoid rediscovering setters and storage names, and skips validation when a concrete parent is already valid and the child adds neither properties nor a validator. `validate_properties()` uses the cached validation plan and directly reads stored attributes for ordinary non-S4 objects, avoiding repeated generic `prop()` lookups.

## Benchmarks

I ran `bench/constructor.R` back-to-back against the combined #737 + #743 baseline and this prototype on arm64 with R 4.5.3.

| Case | #737 + #743 | Prototype | Change |
|---|---:|---:|---:|
| Depth 1 | 25 µs | 20 µs | 1.2x faster |
| Depth 5 | 120 µs | 100 µs | 1.2x faster |
| Depth 10 | 260 µs | 210 µs | 1.2x faster |
| Width 0 | 25 µs | 20 µs | 1.2x faster |
| Width 10 | 67 µs | 48 µs | 1.4x faster |
| Width 50 | 230 µs | 130 µs | 1.8x faster |

The cached metadata increases marginal class-graph memory by approximately 17%. A production version could likely reduce that by using more compact parallel vectors or moving some of the validation plan into C.

## Validation

- `air format .`
- `devtools::test()`: 1,289 passed
- `git diff --check`
